### PR TITLE
Docs: Add orchestration panel & UI task-seed workflow, broaden provider support, and record multi‑agent readiness

### DIFF
--- a/.ralph/prd.md
+++ b/.ralph/prd.md
@@ -777,6 +777,23 @@ Acceptance criteria:
 - Panel updates on each iteration-completion event with refreshed graph state.
 - `npm run validate` passes.
 
+**4. UI task seeding from epic/feature request**
+
+Add a first-class UI workflow that lets an operator seed backlog tasks directly from an epic/feature-level request, without hand-editing `tasks.json`. Concrete work:
+
+- Add a command/UI entry point (for example from the sidebar and command palette) that prompts the operator to describe the desired epic or feature at a high level.
+- Route the request through the same deterministic task-creation pipeline used by other task producers, so generated tasks preserve schema invariants and normalized fields.
+- Produce structured task objects and append them to `.ralph/tasks.json` as valid task entries (IDs, status, dependency metadata, and optional rich fields when available).
+- Persist generation evidence as a durable artifact so operators can audit the source request and resulting seeded tasks.
+- Surface a clear success/failure summary in the UI, including how many tasks were created and where they were written.
+
+Acceptance criteria:
+- Operator can trigger the flow from a UI surface and submit an epic/feature request in one interaction path.
+- Generated output is persisted as valid task objects in `.ralph/tasks.json` (not freeform markdown).
+- Task writes pass through the shared normalization + persistence boundary and respect task-schema invariants.
+- Failure paths (provider error, parse failure, schema rejection) produce deterministic user-facing diagnostics with no partial corrupt writes.
+- `npm run validate` passes.
+
 ### Design principles and scope boundaries
 
 **Brand name: Ralphdex.** All user-visible strings — command palette labels, display names, notifications, status messages, README, CHANGELOG, and Marketplace metadata — must use "Ralphdex" as the product name. References to "Ralph Codex", "ralph-codex", "Ralph codex", or similar variants must not appear in any surface the end user can see. Internal identifiers (command IDs such as `ralphCodex.*`, config keys, file/directory names like `.ralph/`) are exempt and may retain their current form to avoid breaking changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@
 Ralphdex is a VS Code extension that:
 
 - builds Ralph prompts from durable workspace files
-- hands prepared prompts to Codex through clipboard plus configurable VS Code command IDs
-- runs controlled `codex exec` iterations with deterministic verification, provenance, and stop behavior
+- hands prepared prompts to AI IDE surfaces through clipboard plus configurable VS Code command IDs
+- runs controlled CLI iterations (`codex`, `claude`, `copilot`, `copilot-foundry`, `azure-foundry`, `gemini`) with deterministic verification, provenance, and stop behavior
 
 ## Working Rules
 
@@ -24,8 +24,8 @@ Ralphdex is a VS Code extension that:
 - [docs/invariants.md](docs/invariants.md): control-plane, task-schema, and artifact-model invariants
 - [docs/provenance.md](docs/provenance.md): prompt/plan/invocation/run trust chain
 - [docs/verifier.md](docs/verifier.md): verifier modes, outcome classes, and stop implications
-- [docs/boundaries.md](docs/boundaries.md): explicit non-goals, trust limits, and Codex boundaries
-- [docs/multi-agent-readiness.md](docs/multi-agent-readiness.md): acceptance criteria for lifting the single-agent deferral
+- [docs/boundaries.md](docs/boundaries.md): explicit non-goals, trust limits, and orchestration boundaries
+- [docs/multi-agent-readiness.md](docs/multi-agent-readiness.md): historical acceptance record for the multi-agent readiness milestone
 - [docs/prompt-calibration.md](docs/prompt-calibration.md): token target derivation, recalibration procedure, and reasoning effort overhead
 
 ## Code Owners For Behavior

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/s0l0m0n8und9.ralphdex?label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=s0l0m0n8und9.ralphdex) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A VS Code extension for durable, file-backed agentic coding loops. Ralph keeps your objective, task graph, prompts, run artifacts, and provenance evidence on disk under `.ralph/` so any new Codex session can resume from inspectable state instead of chat history.
+A VS Code extension for durable, file-backed agentic coding loops. Ralph keeps your objective, task graph, prompts, run artifacts, and provenance evidence on disk under `.ralph/` so any new provider-backed session can resume from inspectable state instead of chat history.
 
 **Key capabilities:**
 
@@ -19,7 +19,7 @@ The extension has two execution paths:
 
 ## Who This Is For
 
-This project is for operators who want Codex work to survive across sessions as files instead of chat history, and for developers who want a VS Code extension that can prepare prompts, hand work off to Codex, and run deterministic `codex exec` loops with persisted evidence.
+This project is for operators who want file-backed AI delivery workflows that survive across sessions, and for developers who want a VS Code extension that can prepare prompts, hand work off to an IDE chat surface, and run deterministic CLI iterations with persisted evidence.
 
 ## Installation
 
@@ -36,7 +36,7 @@ Alternatively, install from the command line:
 code --install-extension s0l0m0n8und9.ralphdex
 ```
 
-For a local package build, run `npm run package` from the repo root and install the generated `ralphdex-<version>.vsix` via `Extensions: Install from VSIX...` or `code --install-extension ./ralphdex-<version>.vsix`. For Marketplace release validation without shipping, run `npm run publish:dry-run`. See [docs/release-workflow.md](docs/release-workflow.md) for the supported package and Marketplace publish flow.
+For a local package build, run `npm run package` from the repo root and install the generated `ralphdex-<version>.vsix` via `Extensions: Install from VSIX...` or `code --install-extension ./ralphdex-<version>.vsix`. `npm run publish:dry-run` currently aliases that same packaging check. See [docs/release-workflow.md](docs/release-workflow.md) for the full package and Marketplace publish flow, including explicit `vsce publish --dry-run` usage.
 
 ### Post-Install Tour
 
@@ -100,7 +100,8 @@ Ralph keeps its durable state in the workspace:
 - runtime state: `.ralph/state.json`
 - prompts: `.ralph/prompts/`
 - transcripts: `.ralph/runs/`
-- clean-stop session handoffs: `.ralph/handoff/`
+- clean-stop session handoff notes: `.ralph/handoff/`
+- role-to-role handoff contracts: `.ralph/handoffs/`
 - artifacts and latest pointers: `.ralph/artifacts/`
 - logs: `.ralph/logs/extension.log`
 
@@ -120,7 +121,7 @@ For day-to-day loop inspection:
 
 1. `Ralphdex: Show Status` opens or focuses the dashboard with a fresh snapshot covering the selected task, recent history, and stale surfaces. The raw status report is also written to the `Ralphdex` output channel for audit and debugging.
 2. `Ralphdex: Open Latest Ralph Summary` for the newest outcome summary as a text artifact.
-3. `Ralphdex: Open Latest Prompt Evidence` and `Ralphdex: Open Latest CLI Transcript` to inspect what Ralph prepared and what Codex returned.
+3. `Ralphdex: Open Latest Prompt Evidence` and `Ralphdex: Open Latest CLI Transcript` to inspect what Ralph prepared and what the provider returned.
 4. `Ralphdex: Open Failure Diagnosis` to jump straight to the dashboard diagnostics tab for the selected task's persisted recovery context.
 5. `Ralphdex: Open Latest Provenance Bundle` or `Ralphdex: Reveal Latest Provenance Bundle Directory` for the full persisted proof set.
 
@@ -128,12 +129,28 @@ See [docs/workflows.md](docs/workflows.md) for the full operator flow and [docs/
 
 ## Commands
 
+Source of truth: `package.json` (`contributes.commands`) is authoritative for shipped command IDs and titles.
+
+Current command surface:
+
 - `Ralphdex: Initialize Workspace`
+- `Ralphdex: Add Task`
+- `Ralphdex: New Project Wizard`
+- `Ralphdex: New Project`
+- `Ralphdex: Switch Project`
 - `Ralphdex: Prepare Prompt`
 - `Ralphdex: Open Codex IDE`
 - `Ralphdex: Run CLI Iteration`
 - `Ralphdex: Run CLI Loop`
+- `Ralphdex: Run Multi-Agent Loop`
+- `Ralph: Run Review Agent`
+- `Ralph: Run Watchdog Agent`
+- `Ralph: Run SCM Agent`
 - `Ralphdex: Show Status`
+- `Ralphdex: Show Multi-Agent Status`
+- `Ralphdex: Open Failure Diagnosis`
+- `Ralphdex: Auto-Recover Task`
+- `Ralphdex: Skip Task`
 - `Ralphdex: Open Latest Ralph Summary`
 - `Ralphdex: Open Latest Provenance Bundle`
 - `Ralphdex: Open Latest Prompt Evidence`
@@ -143,10 +160,17 @@ See [docs/workflows.md](docs/workflows.md) for the full operator flow and [docs/
 - `Ralphdex: Reveal Latest Provenance Bundle Directory`
 - `Ralphdex: Cleanup Runtime Artifacts`
 - `Ralphdex: Reset Runtime State`
+- `Ralphdex: Show Dashboard`
+- `Ralphdex: Open Dashboard`
 - `Ralphdex: Run Pipeline`
 - `Ralphdex: Approve Human Review`
 - `Ralphdex: Open Latest Pipeline Run`
 - `Ralphdex: Resume Pipeline`
+- `Ralphdex: Construct Recommended Skills`
+- `Ralphdex: Regenerate PRD`
+- `Ralphdex: Requeue Dead-Letter Task`
+- `Ralphdex: Show Sidebar`
+- `Ralphdex: Show Tasks`
 - `Ralphdex: Set Provider Secret`
 - `Ralphdex: Clear Provider Secret`
 
@@ -158,11 +182,13 @@ For the opt-in full pipeline smoke, run `npm run test:e2e-pipeline` with `RALPH_
 
 All settings are under the `ralphCodex.*` namespace in VS Code settings (`Ctrl+,` / `Cmd+,`).
 
+This section lists **core settings** only. Source of truth for the full settings surface (including defaults and enum values) is `package.json` (`contributes.configuration.properties`).
+
 **Provider**
 
 | Setting | Default | Description |
 |---|---|---|
-| `ralphCodex.cliProvider` | `"claude"` | CLI backend: `codex`, `claude`, `copilot`, `copilot-foundry`, or `azure-foundry` |
+| `ralphCodex.cliProvider` | `"claude"` | CLI backend: `codex`, `claude`, `copilot`, `copilot-foundry`, `azure-foundry`, or `gemini` |
 | `ralphCodex.codexCommandPath` | `"codex"` | Codex CLI executable path or name; on Windows, bare command names also resolve `codex.cmd`/`codex.bat` wrappers |
 | `ralphCodex.claudeCommandPath` | `"claude"` | Claude CLI executable path or name |
 | `ralphCodex.copilotCommandPath` | `"copilot"` | Copilot CLI executable path or name |
@@ -180,14 +206,14 @@ Azure-backed providers use grouped settings and secure auth references instead o
 | Setting | Default | Description |
 |---|---|---|
 | `ralphCodex.agentId` | `"default"` | Identity written into claims and artifacts; set uniquely per concurrent loop |
-| `ralphCodex.agentRole` | `"build"` | Role contract: `build`, `review`, `watchdog`, or `scm` |
+| `ralphCodex.agentRole` | `"implementer"` | Role contract for iteration selection/policy (`build`, `review`, `watchdog`, `scm`, `planner`, `implementer`, `reviewer`) |
 | `ralphCodex.agentCount` | `1` | Number of concurrent agent instances |
 
 **Loop behavior**
 
 | Setting | Default | Description |
 |---|---|---|
-| `ralphCodex.ralphIterationCap` | `5` | Maximum CLI iterations for the loop command |
+| `ralphCodex.ralphIterationCap` | `5` | Maximum CLI iterations for the loop command (operator presets can raise this) |
 | `ralphCodex.autonomyMode` | `"autonomous"` | `supervised` or `autonomous` |
 | `ralphCodex.stopOnHumanReviewNeeded` | `true` | Stop the loop on `needs_human_review` classification |
 | `ralphCodex.autoReplenishBacklog` | `true` | Continue into backlog replenishment when no actionable task remains |
@@ -201,7 +227,7 @@ Azure-backed providers use grouped settings and secure auth references instead o
 | Setting | Default | Description |
 |---|---|---|
 | `ralphCodex.model` | `"claude-sonnet-4-6"` | Default model for CLI runs |
-| `ralphCodex.claudeMaxTurns` | `50` | Maximum agentic turns per Claude CLI invocation |
+| `ralphCodex.claudeMaxTurns` | `125` | Maximum agentic turns per Claude CLI invocation |
 | `ralphCodex.claudePermissionMode` | `"dangerously-skip-permissions"` | Claude CLI permission mode for unattended runs |
 | `ralphCodex.reasoningEffort` | `"medium"` | Reasoning effort for Codex CLI runs |
 | `ralphCodex.cliExecutionTimeoutMs` | `0` | CLI iteration timeout in ms; `0` disables the timeout |
@@ -227,9 +253,25 @@ Azure-backed providers use grouped settings and secure auth references instead o
 |---|---|---|
 | `ralphCodex.promptIncludeVerifierFeedback` | `true` | Include prior iteration and verifier feedback in the next prompt |
 | `ralphCodex.promptPriorContextBudget` | `8` | Maximum prior-iteration bullet lines carried into the next prompt |
-| `ralphCodex.promptBudgetProfile` | `"claude"` | Prompt-budget policy: `codex`, `claude`, or `custom` |
+| `ralphCodex.promptBudgetProfile` | `"codex"` | Prompt-budget policy: `codex`, `claude`, or `custom` |
 | `ralphCodex.promptTemplateDirectory` | `""` | Path to custom prompt templates; empty uses bundled templates |
 | `ralphCodex.clipboardAutoCopy` | `true` | Copy generated prompts to clipboard automatically |
+
+**Multi-agent and pipeline**
+
+| Setting | Default | Description |
+|---|---|---|
+| `ralphCodex.pipelineHumanGates` | `false` | Pause pipeline after review-agent pass until `Approve Human Review` |
+| `ralphCodex.operatorMode` | _unset_ | Optional preset (`simple`, `multi-agent`, `hardcore`) that seeds multiple defaults |
+| `ralphCodex.memoryStrategy` | `"verbatim"` | Iteration memory strategy: `verbatim`, `sliding-window`, or `summary` |
+
+**Model tiering**
+
+| Setting | Default | Description |
+|---|---|---|
+| `ralphCodex.enableModelTiering` | `true` | Convenience toggle for `ralphCodex.modelTiering.enabled` |
+| `ralphCodex.modelTiering.simpleThreshold` | `2` | Score strictly below this threshold maps to the simple tier |
+| `ralphCodex.modelTiering.complexThreshold` | `6` | Score at or above this threshold maps to the complex tier |
 
 **Artifacts**
 
@@ -257,7 +299,7 @@ Azure-backed providers use grouped settings and secure auth references instead o
 - [docs/provenance.md](docs/provenance.md): plan/prompt/invocation/run trust chain
 - [docs/verifier.md](docs/verifier.md): verifier modes, classification rules, and stop semantics
 - [docs/boundaries.md](docs/boundaries.md): explicit non-goals and trust limits
-- [docs/multi-agent-readiness.md](docs/multi-agent-readiness.md): acceptance criteria for lifting the single-agent deferral
+- [docs/multi-agent-readiness.md](docs/multi-agent-readiness.md): historical record of the 2026-03-17 multi-agent readiness milestone
 - [docs/prompt-calibration.md](docs/prompt-calibration.md): token target derivation, recalibration procedure, and reasoning effort overhead
 - [docs/release-workflow.md](docs/release-workflow.md): version bump, packaging, and VS Code Marketplace publish procedure
 - [docs/failure-recovery.md](docs/failure-recovery.md): failure category taxonomy, recovery playbooks, and diagnostic cost
@@ -267,5 +309,5 @@ Azure-backed providers use grouped settings and secure auth references instead o
 - Prompt templates live in `prompt-templates/` and are selected deterministically.
 - Set `ralphCodex.inspectionRootOverride` when an umbrella workspace contains multiple plausible child repos.
 - CLI runs default `ralphCodex.reasoningEffort` to `medium`. Raise it to `high` only as an explicit escalation for architecture or hard debugging work.
-- The shipped automation surface is a sequential single-agent loop; multi-agent orchestration is a planned milestone with explicit acceptance criteria in [docs/multi-agent-readiness.md](docs/multi-agent-readiness.md).
+- Ralphdex ships both sequential CLI loops and built-in multi-agent/pipeline orchestration flows; see [docs/workflows.md](docs/workflows.md) for operator paths and [docs/boundaries.md](docs/boundaries.md) for explicit guardrails.
 - For manual prompt-budget recalibration, run `npm run prompt:calibrate -- <workspace-path>` and use [docs/prompt-calibration.md](docs/prompt-calibration.md) as the procedure.

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -7,26 +7,26 @@ Related docs:
 - [Architecture](architecture.md) for module shape
 - [Provenance](provenance.md) for trust-chain details
 - [Verifier](verifier.md) for stop and review semantics
-- [Multi-Agent Readiness](multi-agent-readiness.md) for the explicit acceptance criteria that must be met before this boundary changes
+- [Multi-Agent Readiness](multi-agent-readiness.md) for the historical acceptance record that unlocked built-in multi-agent orchestration
 
 ## Codex Product Boundary
 
 Supported paths:
 
 - IDE handoff through clipboard plus `vscode.commands.executeCommand(...)`
-- scripted automation through `codex exec`
+- scripted automation through provider CLI/direct execution (`codex`, `claude`, `copilot`, `copilot-foundry`, `azure-foundry`, `gemini`)
 
 Unsupported assumptions:
 
 - direct composer injection
-- private or invented Codex IDE APIs
+- private or invented AI IDE APIs
 - treating `preferredHandoffMode = cliExec` as if `Open Codex IDE` should run the CLI
 
 ## Trust Boundary
 
 Ralph proves different things on different paths:
 
-- CLI execution: prepared prompt, persisted plan, and stdin payload integrity up to the `codex exec` boundary
+- CLI/direct execution: prepared prompt, persisted plan, and launch payload integrity up to the provider execution boundary
 - IDE handoff: prepared prompt bundle only
 
 Ralph does not prove:
@@ -39,11 +39,19 @@ Ralph does not prove:
 
 Ralph is intentionally deterministic. It does not try to become a general autonomous planner.
 
-The current shipped control plane is a sequential iteration/loop runner. Multi-agent orchestration acceptance criteria (task ownership, write serialisation, and remediation isolation) were satisfied on 2026-03-17; see [docs/multi-agent-readiness.md](multi-agent-readiness.md) for the full record. Broad concurrent multi-agent orchestration remains an operator concern; Ralph does not coordinate multiple agents automatically.
+The current shipped control plane includes:
+
+- sequential single-iteration and loop commands
+- built-in multi-agent loop orchestration
+- pipeline orchestration with durable checkpoints, optional human-review gate, and resume support
+
+The 2026-03-17 readiness criteria for task ownership, write serialisation, and remediation isolation were satisfied before this multi-agent surface shipped; see [docs/multi-agent-readiness.md](multi-agent-readiness.md) for the acceptance record.
+
+The single-agent CLI iteration/loop runner still exists as a first-class command path, but it now sits alongside shipped multi-agent and pipeline orchestration commands.
 
 Durable `.ralph` state remains control-plane-owned during normal CLI task execution. The model may propose selected-task status through the structured completion report, but Ralph is the only component that persists `.ralph/tasks.json` or `.ralph/progress.md` on that path.
 
-Autonomy mode does not change the principal-agent model. The operator remains the principal, `autonomyMode` only changes a bounded set of loop defaults, and hard stops such as `needs_human_review`, `request_human_review`, initial PRD authorship, and blocking preflight diagnostics stay enforced regardless of mode.
+Autonomy mode does not change the principal-agent model. The operator remains the principal, and `autonomyMode` only changes a bounded set of loop defaults. Blocking preflight diagnostics and explicit task/provenance contracts remain enforced; hard stops and human-review behavior follow the configured gates (`stopOnHumanReviewNeeded`, `pipelineHumanGates`, and operator presets).
 
 It does not:
 
@@ -52,7 +60,7 @@ It does not:
 - replace deterministic stop logic with freeform intent inference
 - inject raw transcript dumps into future prompts
 - build a deep repo indexer or full-repo enumeration pass as part of prompt shaping
-- spawn or coordinate multiple Codex agents against the same workspace as part of the built-in loop
+- become an open-ended autonomous swarm without bounded roles, deterministic state transitions, and durable artifact evidence
 
 ## Repository Layout And Workspace State
 
@@ -82,7 +90,7 @@ Workspace boundaries:
 
 - untrusted workspaces support status inspection only
 - virtual workspaces are unsupported
-- the workspace must be a real local folder because Ralph reads and writes durable files and may launch the Codex CLI
+- the workspace must be a real local folder because Ralph reads and writes durable files and may launch provider CLIs or direct provider calls
 
 ## Git And Safety Boundary
 
@@ -102,7 +110,7 @@ The repo does not currently try to prove through automated tests:
 
 - live clipboard handoff behavior in a real host OS session
 - live VS Code command handoff behavior in a real Extension Development Host session
-- real `codex exec` execution against the Codex service
+- real provider-backed execution against live external services
 - heavy Extension Development Host UI automation
 
 Those areas require manual verification when changed.

--- a/docs/model-tiering.md
+++ b/docs/model-tiering.md
@@ -4,7 +4,9 @@ Ralph routes each task to a model tier based on a deterministic complexity score
 
 ## Enabling Model Tiering
 
-Model tiering is enabled by default (`ralphCodex.enableModelTiering: true`). Set it to `false` to fall back to the single model configured in `ralphCodex.model` for all tasks.
+Model tiering is enabled by default (`ralphCodex.modelTiering.enabled: true`). The legacy convenience flag `ralphCodex.enableModelTiering` is also supported and overrides the nested `enabled` field when explicitly set.
+
+Set tiering to `false` to fall back to the single model configured in `ralphCodex.model` for all tasks.
 
 ## Scoring Signals
 
@@ -22,11 +24,13 @@ The total score is the sum of all contributing signals.
 
 ## Tier Thresholds
 
-Scores map to tiers using two thresholds (the `ralphCodex.complexityTierThresholds` within `ralphCodex.modelTiering`):
+Scores map to tiers using two thresholds in `ralphCodex.modelTiering` (`simpleThreshold` and `complexThreshold`):
+
+Historical note: some older docs and settings discussions refer to these thresholds as `ralphCodex.complexityTierThresholds`; the active shipped surface is the nested `ralphCodex.modelTiering` object.
 
 | Score range | Tier | Default model |
 |---|---|---|
-| `score < simpleThreshold` (default: 2) | simple | `claude-haiku-4-5-20251001` |
+| `score < simpleThreshold` (default: 2) | simple | `provider: copilot`, `model: claude-opus-4-6` |
 | `simpleThreshold ≤ score < complexThreshold` | medium | `claude-sonnet-4-6` |
 | `score ≥ complexThreshold` (default: 6) | complex | `claude-opus-4-6` |
 
@@ -46,15 +50,17 @@ Each tier can specify a `model` string and an optional `provider` override:
 ```json
 "ralphCodex.modelTiering": {
   "enabled": true,
-  "simple":  { "model": "claude-haiku-4-5-20251001" },
-  "medium":  { "model": "claude-sonnet-4-6" },
-  "complex": { "model": "claude-opus-4-6" },
+  "simple":  { "provider": "copilot", "model": "claude-opus-4-6" },
+  "medium":  { "provider": "claude", "model": "claude-sonnet-4-6" },
+  "complex": { "provider": "claude", "model": "claude-opus-4-6" },
   "simpleThreshold": 2,
   "complexThreshold": 6
 }
 ```
 
 Omitting `provider` uses the workspace default (`ralphCodex.cliProvider`). Set `provider` to route a specific tier through a different CLI provider (e.g. `"copilot"` for simple tasks, `"claude"` for complex).
+
+Source of truth for shipped defaults is `package.json` (`contributes.configuration.properties.ralphCodex.modelTiering`).
 
 ## Expected Cost Savings
 

--- a/docs/multi-agent-readiness.md
+++ b/docs/multi-agent-readiness.md
@@ -1,10 +1,10 @@
 # Multi-Agent Readiness
 
-This document records the acceptance criteria that must be satisfied before Ralph removes the current single-agent loop restriction. Each acceptance criterion stays durable and file-backed.
+This document records the acceptance criteria that were required to lift the historical single-agent deferral. The milestone was satisfied on **2026-03-17** and the criteria remain as the durable acceptance record.
 
 Related docs:
 
-- [Boundaries](boundaries.md) for the currently enforced single-agent boundary
+- [Boundaries](boundaries.md) for the current shipped orchestration and trust boundaries
 - [Invariants](invariants.md) for durable control-plane rules
 - [Testing](testing.md) for the authoritative validation gate
 
@@ -37,6 +37,4 @@ Acceptance criterion:
 
 ## Lifting The Deferral
 
-When all three acceptance criteria above are done and `npm run validate` passes, update `docs/boundaries.md` to remove the single-agent loop restriction and update this document to record the date the milestone was satisfied.
-
-Milestone satisfied date: 2026-03-17.
+Each acceptance criterion above is now satisfied, `npm run validate` passed at completion, and the single-agent deferral was lifted on **2026-03-17**.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -41,15 +41,15 @@ npm run package
 
 This runs `check:runtime` then `vsce package --no-dependencies`. Inspect the generated `.vsix` for 0 blocking warnings before continuing.
 
-### 5. Validate the Marketplace publish path without shipping
+### 5. Run the repo-level dry-run script
 
 ```bash
 npm run publish:dry-run
 ```
 
-Run this from the Ralphdex repo root after `npm run package` succeeds. The script validates the package using `npm run package` (equivalent to `vsce package --no-dependencies`), which validates CHANGELOG format, file inclusion, and packaging integrity without shipping a Marketplace release.
+Run this from the Ralphdex repo root after `npm run package` succeeds. In the current script surface, `publish:dry-run` aliases `npm run package` (equivalent to `vsce package --no-dependencies`), so it validates CHANGELOG format, file inclusion, and packaging integrity without shipping a Marketplace release.
 
-Treat this as the final authoritative validation step before the real publish command. A successful run proves the current package, metadata, and extension structure are ready for publishing.
+Treat this as a packaging-readiness check before the real publish command. If you need an explicit Marketplace publish-path dry run, run `npx vsce publish --dry-run --no-dependencies` manually.
 
 ### 6. Commit and tag
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,7 +20,7 @@ Related docs:
 - `npm run test:real-cli-smoke`: run one temp-workspace Ralph iteration through the real `codex exec` path and print the preserved artifact paths. This command is optional and requires a working Codex CLI environment.
 - `npm run validate`: run `compile`, `check:docs`, `check:ledger`, `check:prompt-budget`, `lint`, and `test`.
 - `npm run package`: verify the Node runtime and then build a `.vsix` package with `vsce`.
-- `npm run publish:dry-run`: verify the Node runtime and run `vsce publish --dry-run --no-dependencies` so the Marketplace publish path is validated without shipping a release.
+- `npm run publish:dry-run`: currently an alias to `npm run package` (runtime check + `vsce package --no-dependencies`). It validates packaging readiness without publishing. Use `npx vsce publish --dry-run --no-dependencies` manually when you need an explicit publish-path dry run.
 
 ## What Is Covered
 
@@ -80,7 +80,7 @@ When changing those areas, rely on the authoritative commands above plus manual 
 
 - Packaging is supported on Node 20+.
 - `scripts/ensure-node-version.js` fails fast when `npm run package` is invoked on an older runtime.
-- The same runtime gate also protects `npm run publish:dry-run` before `vsce publish --dry-run --no-dependencies` is attempted.
+- The same runtime gate also protects `npm run publish:dry-run` because that script currently delegates to `npm run package`.
 - Node 18 is intentionally treated as unsupported for packaging because the modern `@vscode/vsce` toolchain requires a newer runtime.
 - The packaged `.vsix` is intentionally allowlisted to compiled runtime files, prompt templates, the bundled license, and operator-facing docs so release builds do not ship `src/`, `test/`, `.ralph/`, or other development-only inputs.
 - `npm run package` proves the repo can emit a `.vsix`, but manual `.vsix` install still needs an operator check through `Extensions: Install from VSIX...` or `code --install-extension`.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -32,7 +32,7 @@ If you prefer a shell-driven local install, run `code --install-extension ./ralp
 
 This workflow proves that the repo can build a distributable `.vsix`. It does not prove marketplace publishing or host-specific install UX; those remain manual operator checks.
 
-For Marketplace release validation, use `npm run publish:dry-run` from the repo root after `npm run package`. That path exercises `vsce publish --dry-run --no-dependencies` without shipping a release; the full procedure lives in [docs/release-workflow.md](release-workflow.md).
+For Marketplace release validation, use `npm run publish:dry-run` from the repo root after `npm run package`. In the current script surface this command aliases `npm run package` (runtime check + `vsce package --no-dependencies`). Use `npx vsce publish --dry-run --no-dependencies` manually when you need an explicit publish-path dry run. The full release procedure lives in [docs/release-workflow.md](release-workflow.md).
 
 ## Initialize A Fresh Workspace
 
@@ -50,7 +50,7 @@ The safety guard is intentionally narrow: if `.ralph/prd.md` already exists, Ral
 
 1. Run `Ralphdex: Prepare Prompt` if you only want the next prompt file.
 2. Run `Ralphdex: Open Codex IDE` if you also want clipboard handoff and best-effort sidebar/new-chat commands.
-3. Continue manually in the Codex IDE.
+3. Continue manually in the selected IDE chat surface.
 
 This path persists prepared-prompt evidence, not a full executed iteration result.
 
@@ -62,8 +62,8 @@ Handoff behavior on this path is intentionally explicit:
 
 - `Prepare Prompt` writes the prompt to disk every time and also copies it to the clipboard when `ralphCodex.clipboardAutoCopy = true`.
 - `Open Codex IDE` is the provider-neutral AI handoff command. With `preferredHandoffMode = clipboard` it copies the prompt only and does not execute `openSidebarCommandId` or `newChatCommandId`.
-- `Open Codex IDE` with `preferredHandoffMode = ideCommand` copies the prompt and then best-effort runs the configured VS Code command IDs. If either command is missing or throws, Ralph warns and tells the operator to open Codex manually and paste the prepared prompt.
-- `Open Codex IDE` with `preferredHandoffMode = cliExec` still stays on clipboard handoff for this command and warns to use `Run CLI Iteration` for real `codex exec` automation.
+- `Open Codex IDE` with `preferredHandoffMode = ideCommand` copies the prompt and then best-effort runs the configured VS Code command IDs. If either command is missing or throws, Ralph warns and tells the operator to open the chat surface manually and paste the prepared prompt.
+- `Open Codex IDE` with `preferredHandoffMode = cliExec` still stays on clipboard handoff for this command and warns to use `Run CLI Iteration` for real provider execution automation.
 
 Artifacts written on this path include:
 
@@ -80,9 +80,9 @@ When `ralphCodex.generatedArtifactRetentionCount` is greater than `0`, Ralph als
 ## Run One CLI Iteration
 
 1. Run `Ralphdex: Run CLI Iteration`.
-2. Ralph emits a short preflight summary covering task graph, workspace/runtime, Codex adapter, and verifier readiness, including warnings when latest artifact surfaces are stale, retention cleanup roots overlap unsafely, or retention settings disable expected cleanup before a loop starts.
-3. If preflight is blocked, Ralph persists blocked-start evidence and stops before `codex exec`.
-4. Otherwise Ralph selects the next task, renders the prompt, writes the execution plan, verifies launch integrity, runs `codex exec`, verifies the outcome, reconciles the structured completion report, and persists the iteration result.
+2. Ralph emits a short preflight summary covering task graph, workspace/runtime, provider adapter, and verifier readiness, including warnings when latest artifact surfaces are stale, retention cleanup roots overlap unsafely, or retention settings disable expected cleanup before a loop starts.
+3. If preflight is blocked, Ralph persists blocked-start evidence and stops before provider launch.
+4. Otherwise Ralph selects the next task, renders the prompt, writes the execution plan, verifies launch integrity, runs the configured provider execution path, verifies the outcome, reconciles the structured completion report, and persists the iteration result.
 
 Operator-facing artifacts for this path include:
 
@@ -94,6 +94,8 @@ Operator-facing artifacts for this path include:
 - `.ralph/artifacts/latest-provenance-summary.md`
 
 When a CLI iteration stops cleanly instead of crashing, Ralph also writes a compact session handoff note under `.ralph/handoff/<agentId>-<iteration>.json`. This handoff file is the durable carry-forward surface for the next fresh session. It records the selected task, stop reason, completion classification, any progress note or blocker, the latest validation failure signature when one exists, and the remaining-task summary at the moment the loop stopped.
+
+This `.ralph/handoff/` location is for per-iteration session notes. Role-to-role handoff contracts used by orchestration lifecycle controls persist separately under `.ralph/handoffs/`.
 
 Clean handoff notes are written only for terminal stop reasons that preserve inspectable continuity instead of failure ambiguity:
 
@@ -121,7 +123,7 @@ The operator approval boundary is strict on purpose:
 - approval is still validated at write time, so stale, duplicate, or graph-invalid proposed children are rejected instead of being forced into the task graph
 - the approved write is narrow: Ralph appends the proposed child tasks and adds them as parent dependencies, but it does not reorder or rewrite unrelated tasks
 
-On execution failures, the structured iteration result and latest-result pointer should also carry the summarized `codex exec` message, while the transcript and `stderr.log` keep the full raw process output for inspection.
+On execution failures, the structured iteration result and latest-result pointer should also carry the summarized provider-launch message, while the transcript and `stderr.log` keep the full raw process output for inspection.
 
 For normal task execution, the prompt explicitly tells the model not to edit `.ralph/tasks.json` or `.ralph/progress.md` directly. Backlog replenishment is the exception: that prompt kind still updates the durable task file and progress log itself.
 
@@ -129,7 +131,7 @@ Use this path when you need repeatable execution plus deterministic result recor
 
 When `ralphCodex.scmStrategy = branch-per-task`, CLI iteration also owns branch placement for the selected task. Top-level tasks claim a dedicated `ralph/<taskId>` branch from the branch that was active when the claim was acquired. Child tasks claim both `ralph/integration/<parentId>` and `ralph/<taskId>`, record those branch names plus the original base branch in `.ralph/claims.json`, and run the task on the child feature branch. When the child task reconciles `done`, Ralph commits the remaining work on `ralph/<taskId>`, merges that feature branch into `ralph/integration/<parentId>`, and, if that completion also auto-completes the parent aggregate task, performs one atomic merge from `ralph/integration/<parentId>` back into the recorded base branch. If `ralphCodex.scmPrOnParentDone = true`, Ralph also pushes `ralph/integration/<parentId>` to `origin` and runs `gh pr create` with the parent title plus the completed child summaries, targeting the base branch recorded on the first child claim. Push or PR failures are surfaced in iteration warnings only; they do not roll back the completed task state. Ralph never auto-deletes either branch. If any of those merges conflict, Ralph leaves the conflicting branch checked out, reopens the affected task as `in_progress` with a merge-conflict blocker, releases the active claim, and records the conflict path in the iteration warnings instead of silently forcing the merge.
 
-If `Show Status` reports a stale canonical task claim that blocks reselection, use `Ralphdex: Resolve Stale Task Claim` instead of editing `.ralph/claims.json` manually. The command inspects the current canonical claim, refuses to proceed unless the claim is still stale, checks that no `codex exec` process is currently running, and then asks for explicit operator approval before it marks that claim `stale` in `.ralph/claims.json`. Ralph records the resolved task id, provenance id, resolution timestamp, and recovery reason on the claim so later status output can explain why the claim became eligible for recovery.
+If `Show Status` reports a stale canonical task claim that blocks reselection, use `Ralphdex: Resolve Stale Task Claim` instead of editing `.ralph/claims.json` manually. The command inspects the current canonical claim, refuses to proceed unless the claim is still stale, checks that no provider process is currently running, and then asks for explicit operator approval before it marks that claim `stale` in `.ralph/claims.json`. Ralph records the resolved task id, provenance id, resolution timestamp, and recovery reason on the claim so later status output can explain why the claim became eligible for recovery.
 
 After that recovery step, the task is eligible for normal deterministic reselection again. The next `Run CLI Iteration` must acquire a fresh CLI claim for that task if it is still the next actionable item, and it must release that CLI claim again when the iteration finishes.
 


### PR DESCRIPTION
### Motivation

- Surface a built-in orchestration dashboard and a first-class UI flow for seeding tasks from epic/feature requests so operators can inspect and create backlog items without hand-editing `.ralph/tasks.json`.
- Make the product language provider-neutral (avoid Codex-only wording) and expand supported provider/CLI surfaces so the extension can use multiple provider backends.
- Record and ship the multi-agent/pipeline readiness milestone and update runtime boundaries, settings, and documentation to reflect the new orchestration surface.

### Description

- Add orchestration dashboard and UI seeding acceptance text and requirements to `.ralph/prd.md`, including `ralphCodex.showOrchestrationPanel` and a UI flow to seed tasks into `.ralph/tasks.json` with durable generation evidence.
- Update product docs (`README.md`, `AGENTS.md`, `docs/*`) to use provider-neutral wording, list additional CLI providers (including `gemini`) and provider execution paths, and expand the commands/settings matrix (new commands, model-tiering config, `agentRole` defaults, `claudeMaxTurns`, prompt-budget/profile, pipeline and model-tiering settings, and `handoffs`/`handoff` locations).
- Record that multi-agent/pipeline orchestration readiness was satisfied on 2026-03-17 and update `docs/boundaries.md`, `docs/multi-agent-readiness.md`, and related docs to reflect shipped multi-agent and pipeline orchestration flows with durable checkpoints and human gates.
- Clarify packaging/release and testing guidance by documenting that `npm run publish:dry-run` currently aliases `npm run package` and updating references to provider/direct-execution language and artifacts retention/handoff semantics.

### Testing

- Ran `npm run check:docs` to validate the updated documentation structure and links, and it succeeded.
- Ran the repo validation gate with `npm run validate` (compile + docs + checks + tests) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e429d247f883268321f7c51ab85a3a)