### PR TITLE
Reconcile docs drift: providers, model-tiering, handoff paths, and expose runtime settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Example `.ralph/crew.json` with one planner and two implementers:
 
 ## Brief Codex Boundaries
 
-- IDE handoff is clipboard plus `vscode.commands.executeCommand(...)`; do not invent direct composer injection or unsupported Codex IDE APIs.
-- Scripted automation is `codex exec`.
+- IDE handoff is clipboard plus `vscode.commands.executeCommand(...)`; do not invent direct composer injection or unsupported AI IDE APIs.
+- Scripted automation runs through the configured provider execution path (`codex`, `claude`, `copilot`, `copilot-foundry`, `azure-foundry`, or `gemini`).
 - `preferredHandoffMode = cliExec` does not make `Open Codex IDE` run the CLI.
 - CLI runs can prove prepared-and-executed prompt integrity; IDE handoff only proves the prepared prompt bundle.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A VS Code extension for durable, file-backed agentic coding loops. Ralph keeps y
 **Key capabilities:**
 
 - **File-backed state** — PRD, progress log, and task graph survive across sessions without relying on chat history
-- **Multiple CLI backends** — `codex exec`, Claude CLI (`claude -p`), GitHub Copilot CLI, Copilot CLI with Azure OpenAI BYOK (`copilot-foundry`), and Azure direct HTTPS (`azure-foundry`)
+- **Multiple CLI backends** — Codex CLI (`codex exec`), Claude CLI (`claude -p`), GitHub Copilot CLI, Copilot CLI with Azure OpenAI BYOK (`copilot-foundry`), Azure direct HTTPS (`azure-foundry`), and Google Gemini CLI (`gemini`)
 - **Deterministic loop control** — preflight checks, multi-verifier passes, explicit stop reasons, and bounded remediation
 - **Full provenance** — every iteration writes prompt evidence, git snapshots, and a verifiable trust chain to disk
 - **IDE handoff** — clipboard plus configurable VS Code command delivery for chat-first workflows
@@ -15,7 +15,7 @@ A VS Code extension for durable, file-backed agentic coding loops. Ralph keeps y
 The extension has two execution paths:
 
 - prepare a prompt for AI-IDE handoff through clipboard plus configurable VS Code command IDs
-- run deterministic CLI iterations through the configured provider (`codex`, `claude`, `copilot`, `copilot-foundry`, or `azure-foundry`) with preflight checks, verifier passes, stable artifacts, and explicit stop reasons
+- run deterministic CLI iterations through the configured provider (`codex`, `claude`, `copilot`, `copilot-foundry`, `azure-foundry`, or `gemini`) with preflight checks, verifier passes, stable artifacts, and explicit stop reasons
 
 ## Who This Is For
 

--- a/docs/model-tiering.md
+++ b/docs/model-tiering.md
@@ -1,6 +1,6 @@
 # Model Tiering
 
-Ralph routes each task to a model tier based on a deterministic complexity score. Simple tasks use a cheaper, faster model; complex tasks use a more capable model. This keeps costs proportional to actual task difficulty.
+Ralph routes each task to a model tier based on a deterministic complexity score. Simple tasks use the configured simple-tier provider/model pair, while complex tasks use a more capable tier. This keeps capability allocation proportional to task difficulty.
 
 ## Enabling Model Tiering
 
@@ -64,7 +64,7 @@ Source of truth for shipped defaults is `package.json` (`contributes.configurati
 
 ## Expected Cost Savings
 
-Most tasks in a healthy backlog are simple or medium: a single, bounded objective with no prior failure history and no child tasks. At default thresholds, those tasks score below 2 and land in the simple tier (Haiku), which is significantly cheaper per token than Sonnet or Opus. Complex tasks that genuinely need Opus will have accumulated multiple signals (validation + children + trailing failures), keeping escalations rare and justified.
+Most tasks in a healthy backlog are simple or medium: a single, bounded objective with no prior failure history and no child tasks. At default thresholds, tasks that score below `simpleThreshold` route to the simple tier's configured target. Tasks that genuinely need the complex tier should accumulate multiple signals (validation + children + trailing failures), keeping escalations evidence-driven.
 
 Operators can inspect the selected tier and score for each iteration in the artifact provenance bundle (`verifier-summary.json`).
 
@@ -159,4 +159,4 @@ The distribution is heavily medium-skewed (93.7%), with only 5.6% simple and 0.7
 1. **`has_validation_field` is near-universal.** 233 of 269 done tasks (87%) declare an explicit validation command. At +2 points this single signal pushes almost every task past the `simpleThreshold=2` boundary into medium, leaving the simple tier nearly unused in practice.
 2. **`trailing_complex_classifications` is absent.** Because iteration history is not stored in `tasks.json`, no task accumulates the +1–+4 that would push it to complex. At runtime, repeatedly-failing tasks would score higher and more tasks would reach the `complexThreshold=6` boundary.
 
-**Implication:** The current `simpleThreshold=2` is too low when nearly all tasks declare a validation field. Raising `simpleThreshold` to 3 would classify tasks with only a validation field as simple (score=2), directing them to Haiku. Consider this adjustment if cost reduction on validation-only tasks is a priority. The `complexThreshold=6` appears well-placed: reaching it requires at minimum three coincident signals (e.g., validation + children + long title), reserving Opus for genuinely broad tasks. No immediate change to `complexThreshold` is warranted.
+**Implication:** The current `simpleThreshold=2` is strict when nearly all tasks declare a validation field. Raising `simpleThreshold` to 3 would classify validation-only tasks (score = 2) as simple-tier routes under the configured simple-tier provider/model pair. Consider this adjustment if you want broader simple-tier usage. The `complexThreshold=6` appears well-placed: reaching it requires at minimum three coincident signals (e.g., validation + children + long title), reserving the complex tier for genuinely broad tasks. No immediate change to `complexThreshold` is warranted.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -411,7 +411,7 @@ Use the inspection commands by question, not just by file name:
 - `Show Status`: "What is Ralph doing now, what did the last few iterations do, and did retention or latest-surface repair change anything?" Opens or focuses the dashboard with a fresh snapshot; raw text report also written to the output channel for audit.
 - `Open Latest Ralph Summary`: "What was the newest iteration outcome in human-readable form?"
 - `Open Latest Prompt Evidence`: "Which template, task context, and inspected root snapshot produced the current prompt?"
-- `Open Latest CLI Transcript`: "What did `codex exec` print, or what last message survived when the transcript is unavailable?"
+- `Open Latest CLI Transcript`: "What did the configured provider execution print, or what last message survived when the transcript is unavailable?"
 - `Open Latest Provenance Bundle` or `Reveal Latest Provenance Bundle Directory`: "Which persisted proof artifacts back the newest attempt end to end?"
 
 ## Inspect State

--- a/package.json
+++ b/package.json
@@ -932,6 +932,66 @@
           "maximum": 20,
           "description": "Number of concurrent Ralph agent instances configured for this workspace. Surfaced in preflight and Show Status so operators can verify the intended parallelism before starting a loop."
         },
+        "ralphCodex.hooks": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "beforeIteration": {
+              "type": "string",
+              "default": "",
+              "description": "Optional shell command hook that runs before each CLI iteration starts."
+            },
+            "afterIteration": {
+              "type": "string",
+              "default": "",
+              "description": "Optional shell command hook that runs after each CLI iteration completes."
+            },
+            "onTaskComplete": {
+              "type": "string",
+              "default": "",
+              "description": "Optional shell command hook that runs when a task is reconciled to done."
+            },
+            "onStop": {
+              "type": "string",
+              "default": "",
+              "description": "Optional shell command hook that runs when a loop run stops for any reason."
+            },
+            "onFailure": {
+              "type": "string",
+              "default": "",
+              "description": "Optional shell command hook that runs when an iteration reports executionStatus=failed."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Optional lifecycle hook commands. Each configured value is a shell command string executed at the named lifecycle point; hook failures are logged but do not stop the loop."
+        },
+        "ralphCodex.autoWatchdogOnStall": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically run the watchdog agent after a loop stop caused by repeated no-progress or repeated identical failure classification."
+        },
+        "ralphCodex.autoReviewOnParentDone": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically run the review agent after a parent task is completed."
+        },
+        "ralphCodex.autoReviewOnLoopComplete": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically run the review agent when a loop command completes with at least one iteration result."
+        },
+        "ralphCodex.autoScmOnConflict": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, branch-per-task conflict handling can auto-invoke the SCM conflict path and retry up to scmConflictRetryLimit."
+        },
+        "ralphCodex.scmConflictRetryLimit": {
+          "type": "number",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Maximum number of automatic SCM conflict retries attempted when autoScmOnConflict is enabled."
+        },
         "ralphCodex.pipelineHumanGates": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
### Motivation
- Fix remaining documentation inconsistencies left after the last doc refresh so docs accurately reflect the runtime surface and package metadata.
- Align top-level provider lists, IDE-vs-CLI handoff boundaries, and model-tiering narrative to the actual configured defaults and code behavior.
- Make `package.json` truthful about the user-facing configuration surface for settings that are consumed at runtime by `readConfig.ts`.

### Description
- Updated `README.md` to include `gemini` in the top-level "Multiple CLI backends" list and in the configured-provider execution-path list so the README matches `package.json`'s `cliProvider` enum.  
- Rewrote the small AGENTS.md Codex-only leftover to keep the IDE handoff constraint while describing scripted automation provider-neutrally (now lists `codex`, `claude`, `copilot`, `copilot-foundry`, `azure-foundry`, `gemini`).  
- Edited `docs/model-tiering.md` to remove the stale “Haiku/cheaper” framing and make the "Expected Cost Savings" and "Threshold Assessment" text consistent with the configured defaults and tiering table.  
- Made one workflows text change to be provider-neutral when referring to the latest CLI transcript (now refers to the configured provider rather than `codex exec`).  
- Added contributed `contributes.configuration.properties` entries to `package.json` for runtime-consumed settings that `readConfig.ts` reads but were not previously surfaced: `ralphCodex.hooks`, `ralphCodex.autoWatchdogOnStall`, `ralphCodex.autoReviewOnParentDone`, `ralphCodex.autoReviewOnLoopComplete`, `ralphCodex.autoScmOnConflict`, and `ralphCodex.scmConflictRetryLimit`.  
- Verified handoff paths in source: session handoff notes are under `.ralph/handoff/` and durable role-to-role handoff contracts are under `.ralph/handoffs/`, and left docs aligned to that truth.

### Testing
- Ran `npm run check:docs` and the docs validation passed after the changes.  
- Ran `npm run compile` (TypeScript compile) and it completed successfully.  
- Ran the repo validation via `npm run validate`; the compile/docs/checks passed but the full test suite produced unrelated failing assertions in the existing tests (the run reported multiple test failures — sample failing tests include `Test Current Provider Connection`, `task tree provider separates active and dead-letter tasks`, and `inspectValidationCommandReadiness`), so the changes here are limited to docs and package metadata and did not introduce the test regressions.  
- No behavioral code changes were made except the `package.json` configuration additions to truthfully expose runtime-consumed settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43f4246d8832681c66a0d61a2e92e)