### PR TITLE
Align Copilot BYOK preflight base-URL checks with runtime resolution

### DIFF
--- a/src/ralph/preflight.ts
+++ b/src/ralph/preflight.ts
@@ -381,8 +381,12 @@ function collectCopilotByokReadinessDiagnostics(config: RalphCodexConfig): Ralph
 
   // Check base URL is resolvable
   const hasOverride = !!cfg.baseUrlOverride.trim();
+  const hasAzureResourceDeployment = !!cfg.azure.resourceName.trim() && !!cfg.azure.deployment.trim();
   if (effectiveProviderType === 'azure') {
-    if (!cfg.azure.resourceName.trim() || !cfg.azure.deployment.trim()) {
+    const baseUrlResolvable = providerId === 'copilot-foundry'
+      ? hasAzureResourceDeployment
+      : hasOverride || hasAzureResourceDeployment;
+    if (!baseUrlResolvable) {
       diagnostics.push(createDiagnostic(
         'codexAdapter',
         'error',

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1382,6 +1382,112 @@ test('buildPreflightReport emits info when copilot-foundry API-key readiness is 
   );
 });
 
+test('buildPreflightReport allows copilot-byok azure when baseUrlOverride is configured without azure resource/deployment', () => {
+  const taskInspection = inspectTaskFileText(JSON.stringify({
+    version: 2,
+    tasks: [{ id: 'T1', title: 'Use Copilot BYOK', status: 'todo' }]
+  }));
+
+  const report = buildPreflightReport({
+    rootPath: '/workspace',
+    workspaceTrusted: true,
+    config: {
+      ...DEFAULT_CONFIG,
+      cliProvider: 'copilot-byok',
+      copilotFoundry: {
+        ...DEFAULT_CONFIG.copilotFoundry,
+        providerType: 'azure',
+        baseUrlOverride: 'https://example.azure.com/openai/deployments/my-deployment',
+        azure: {
+          ...DEFAULT_CONFIG.copilotFoundry.azure,
+          resourceName: '',
+          deployment: ''
+        }
+      }
+    },
+    taskInspection,
+    taskCounts: { todo: 1, in_progress: 0, blocked: 0, done: 0 },
+    selectedTask: null,
+    taskValidationHint: null,
+    validationCommand: null,
+    normalizedValidationCommandFrom: null,
+    validationCommandReadiness: { command: null, status: 'missing', executable: null },
+    fileStatus
+  });
+
+  assert.equal(report.ready, true);
+  assert.ok(!report.diagnostics.some((d) => d.code === 'copilot_byok_base_url_missing'));
+});
+
+test('buildPreflightReport keeps copilot-foundry strict and ignores baseUrlOverride when azure resource/deployment are missing', () => {
+  const taskInspection = inspectTaskFileText(JSON.stringify({
+    version: 2,
+    tasks: [{ id: 'T1', title: 'Use Copilot Foundry', status: 'todo' }]
+  }));
+
+  const report = buildPreflightReport({
+    rootPath: '/workspace',
+    workspaceTrusted: true,
+    config: {
+      ...DEFAULT_CONFIG,
+      cliProvider: 'copilot-foundry',
+      copilotFoundry: {
+        ...DEFAULT_CONFIG.copilotFoundry,
+        providerType: 'azure',
+        baseUrlOverride: 'https://example.azure.com/openai/deployments/my-deployment',
+        azure: {
+          ...DEFAULT_CONFIG.copilotFoundry.azure,
+          resourceName: '',
+          deployment: ''
+        }
+      }
+    },
+    taskInspection,
+    taskCounts: { todo: 1, in_progress: 0, blocked: 0, done: 0 },
+    selectedTask: null,
+    taskValidationHint: null,
+    validationCommand: null,
+    normalizedValidationCommandFrom: null,
+    validationCommandReadiness: { command: null, status: 'missing', executable: null },
+    fileStatus
+  });
+
+  assert.equal(report.ready, false);
+  assert.ok(report.diagnostics.some((d) => d.code === 'copilot_byok_base_url_missing'));
+});
+
+test('buildPreflightReport requires baseUrlOverride for non-azure copilot-byok provider types', () => {
+  const taskInspection = inspectTaskFileText(JSON.stringify({
+    version: 2,
+    tasks: [{ id: 'T1', title: 'Use Copilot BYOK OpenAI', status: 'todo' }]
+  }));
+
+  const report = buildPreflightReport({
+    rootPath: '/workspace',
+    workspaceTrusted: true,
+    config: {
+      ...DEFAULT_CONFIG,
+      cliProvider: 'copilot-byok',
+      copilotFoundry: {
+        ...DEFAULT_CONFIG.copilotFoundry,
+        providerType: 'openai',
+        baseUrlOverride: ''
+      }
+    },
+    taskInspection,
+    taskCounts: { todo: 1, in_progress: 0, blocked: 0, done: 0 },
+    selectedTask: null,
+    taskValidationHint: null,
+    validationCommand: null,
+    normalizedValidationCommandFrom: null,
+    validationCommandReadiness: { command: null, status: 'missing', executable: null },
+    fileStatus
+  });
+
+  assert.equal(report.ready, false);
+  assert.ok(report.diagnostics.some((d) => d.code === 'copilot_byok_base_url_missing'));
+});
+
 // ---------------------------------------------------------------------------
 // Memory summarization fallback diagnostic
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Preflight could block valid `copilot-byok` Azure configurations by emitting `copilot_byok_base_url_missing` even when `copilotFoundry.baseUrlOverride` was set, diverging from runtime behavior in `CopilotByokCliProvider.resolveBaseUrl()`.
- The change aims to make preflight parity with runtime resolution so operators who supply `baseUrlOverride` for BYOK are not incorrectly blocked while keeping `copilot-foundry` behaviour strict.

### Description
- Updated `collectCopilotByokReadinessDiagnostics()` in `src/ralph/preflight.ts` to compute `hasOverride` and `hasAzureResourceDeployment` and determine `baseUrlResolvable` using provider-specific rules so preflight matches runtime resolution semantics.
- For `cliProvider: "copilot-byok"` with effective Azure provider, preflight now accepts either `copilotFoundry.baseUrlOverride` or both `copilotFoundry.azure.resourceName` and `copilotFoundry.azure.deployment`.
- For `cliProvider: "copilot-foundry"` preflight remains strict and ignores `baseUrlOverride`, requiring both Azure fields, and non-Azure BYOK still requires `baseUrlOverride`.
- No new auth paths, no secret logging or persistence was added, and the existing Azure model fallback behavior (using `azure.deployment` as fallback model id) was preserved.

### Testing
- Added three regression unit tests in `test/preflight.test.ts` covering BYOK Azure + override-only passing, Foundry Azure + override-only failing, and non-Azure BYOK without override failing.
- Compiled tests with `npm run compile:tests` and executed the preflight test bundle via `node --require ./test/register-vscode-stub.cjs --test ./out-test/test/preflight.test.js`, and the suite passed (46/46 tests).
- The change only touched `src/ralph/preflight.ts` and `test/preflight.test.ts` and the new tests validated the intended readiness logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed28eb3f5883268b81de190c516c95)