### PR TITLE
Simplify sidebar surface and clean stale UX language

### DIFF
--- a/src/ui/sidebarHtml.ts
+++ b/src/ui/sidebarHtml.ts
@@ -3,12 +3,11 @@ import {
   buildBaseCss,
   buildProgressBar,
   esc,
-  LOOP_STATE_LABEL,
-  PHASE_LABELS
+  LOOP_STATE_LABEL
 } from './htmlHelpers';
 
 // ---------------------------------------------------------------------------
-// Sidebar-specific CSS (compact launcher)
+// Sidebar-specific CSS (compact operator surface)
 // ---------------------------------------------------------------------------
 
 function buildSidebarCss(): string {
@@ -23,123 +22,6 @@ body {
   background: var(--vscode-sideBar-background);
   padding: 8px;
   overflow-x: hidden;
-}
-
-/* Mode-driven visibility */
-.mode-section { display: block; }
-body[data-mode="simple"] .mode-advanced { display: none; }
-body[data-mode="advanced"] .mode-simple { display: none; }
-
-/* Mode switcher */
-.mode-switcher {
-  margin: 6px 0 10px;
-}
-
-.mode-switcher-label {
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: 1.4px;
-  color: var(--dim);
-  font-weight: 700;
-  margin-bottom: 5px;
-}
-
-.mode-switcher-pills {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 3px;
-  padding: 3px;
-  background: rgba(0, 0, 0, 0.15);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-}
-
-.mode-pill {
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 400;
-  padding: 5px 4px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  background: transparent;
-  color: var(--dim);
-  transition: all 0.15s ease;
-  text-align: center;
-}
-
-.mode-pill.active {
-  background: var(--accent);
-  color: #15131a;
-  font-weight: 600;
-}
-
-.mode-pill:not(.active):hover {
-  background: rgba(255,255,255,0.06);
-  color: var(--fg);
-}
-
-/* Tab nav within sidebar */
-.sidebar-tabs {
-  display: flex;
-  gap: 2px;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 8px;
-}
-
-.sidebar-tab {
-  font-family: inherit;
-  font-size: 11px;
-  padding: 5px 10px;
-  border: none;
-  background: transparent;
-  color: var(--dim);
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
-  transition: all 0.15s ease;
-  margin-bottom: -1px;
-}
-
-.sidebar-tab.active {
-  color: var(--fg);
-  border-bottom-color: var(--accent);
-}
-
-.sidebar-tab-panel { display: none; }
-.sidebar-tab-panel.active { display: block; }
-
-/* Quick actions */
-.quick-actions {
-  display: grid;
-  gap: 1px;
-}
-
-.quick-action {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 5px 8px;
-  font-family: inherit;
-  font-size: 11px;
-  background: transparent;
-  color: var(--dim);
-  border: none;
-  cursor: pointer;
-  border-radius: 4px;
-  transition: all 0.12s ease;
-  text-align: left;
-  width: 100%;
-}
-
-.quick-action:hover {
-  background: rgba(255,255,255,0.05);
-  color: var(--fg);
-}
-
-.quick-shortcut {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  opacity: 0.5;
 }
 
 /* State dot */
@@ -160,6 +42,47 @@ body[data-mode="advanced"] .mode-simple { display: none; }
 
 .state-dot.stopped {
   background: var(--warn);
+}
+
+/* Compact run controls */
+.sidebar-run-controls {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #15131a;
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 85%, white);
+}
+
+.btn-danger {
+  background: color-mix(in srgb, var(--bad) 15%, transparent);
+  color: var(--bad);
+  border-color: color-mix(in srgb, var(--bad) 40%, var(--border));
+}
+
+.btn-spinner {
+  display: none;
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--dim);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+.btn.loading .btn-label { opacity: 0.5; }
+.btn.loading .btn-spinner { display: inline-block; }
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
 /* Current task card */
@@ -217,32 +140,14 @@ body[data-mode="advanced"] .mode-simple { display: none; }
   font-family: var(--font-mono);
 }
 
-/* Simple mode status */
-.simple-status {
+.sidebar-status {
   text-align: center;
   padding: 6px 0;
 }
 
-.simple-status-text {
+.sidebar-status-text {
   font-size: 12px;
   color: var(--dim);
-}
-
-.btn-primary {
-  background: var(--accent);
-  color: #15131a;
-  border-color: var(--accent);
-  font-weight: 600;
-}
-
-.btn-primary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 85%, white);
-}
-
-.btn-danger {
-  background: color-mix(in srgb, var(--bad) 15%, transparent);
-  color: var(--bad);
-  border-color: color-mix(in srgb, var(--bad) 40%, var(--border));
 }
 
 .open-dashboard {
@@ -277,50 +182,11 @@ body[data-mode="advanced"] .mode-simple { display: none; }
   text-align: center;
   font-weight: 600;
 }
-
-.seed-block {
-  margin-top: 10px;
-}
-
-.seed-block textarea {
-  width: 100%;
-  min-height: 76px;
-  resize: vertical;
-  padding: 8px;
-  font: inherit;
-  color: var(--vscode-input-foreground, #ccc);
-  background: rgba(0, 0, 0, 0.18);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-
-.seed-block textarea:focus {
-  outline: none;
-  border-color: var(--accent);
-}
-
-.seed-result {
-  margin-top: 8px;
-  font-size: 11px;
-  padding: 8px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-
-.seed-result.success {
-  border-color: var(--ok);
-  color: var(--ok);
-}
-
-.seed-result.error {
-  border-color: var(--warn);
-  color: var(--warn);
-}
 `;
 }
 
 // ---------------------------------------------------------------------------
-// Sidebar HTML — UXrefresh launcher with mode switcher + current-task card
+// Sidebar HTML — compact launcher/status surface
 // ---------------------------------------------------------------------------
 
 function buildCurrentTaskCard(state: RalphDashboardState): string {
@@ -328,23 +194,25 @@ function buildCurrentTaskCard(state: RalphDashboardState): string {
   const snapshot = state.dashboardSnapshot;
   const taskBoard = snapshot?.taskBoard ?? null;
   const failureEntry = snapshot?.failureFeed.entries[0] ?? null;
-  const deadLetterEntry = snapshot?.deadLetter.entries[0] ?? null;
+  const recoveryEntry = snapshot?.deadLetter.entries[0] ?? null;
   const agentRow = snapshot?.agentGrid.rows[0] ?? null;
 
   const id = currentTask?.id ?? taskBoard?.selectedTaskId ?? null;
   const title = currentTask?.title ?? taskBoard?.selectedTaskTitle ?? null;
+  const blockedCount = taskBoard?.counts?.blocked ?? 0;
+  const recoveryCount = taskBoard?.deadLetterCount ?? 0;
 
-  return `<div class="current-task-card">
-    <div class="current-task-kicker">Live Snapshot</div>
+  return `<div class="current-task-card${blockedCount > 0 || recoveryCount > 0 ? ' blocked' : ''}">
+    <div class="current-task-kicker">Current Work</div>
     ${id ? `<div class="current-task-id">Selected ${esc(id)}</div>` : ''}
     ${title ? `<div class="current-task-title">${esc(title)}</div>` : ''}
     ${taskBoard ? `<div class="snapshot-chip-row">
-      <span class="pill">Blocked ${taskBoard.counts?.blocked ?? 0}</span>
-      <span class="pill">Dead-Letter ${taskBoard.deadLetterCount}</span>
+      <span class="pill">Blocked ${blockedCount}</span>
+      <span class="pill">Recovery Queue ${recoveryCount}</span>
       <span class="pill">Next ${taskBoard.nextIteration}</span>
     </div>` : ''}
     ${failureEntry ? `<div class="current-task-failure">⚠ ${esc(failureEntry.category)} · ${esc(failureEntry.confidence)}</div>` : ''}
-    ${deadLetterEntry ? `<div class="current-task-meta">Dead-letter: ${esc(deadLetterEntry.taskTitle)}</div>` : ''}
+    ${recoveryEntry ? `<div class="current-task-meta">Recovery: ${esc(recoveryEntry.taskTitle)}</div>` : ''}
     ${agentRow ? `<div class="current-task-meta">${esc(agentRow.agentId)}</div>` : ''}
     ${!id && !taskBoard ? '<div class="current-task-empty">No task selected</div>' : ''}
   </div>`;
@@ -354,7 +222,6 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
   const stateLabel = LOOP_STATE_LABEL[state.loopState];
   const isRunning = state.loopState === 'running';
 
-  // Phase indicator for running lane
   let phaseIndicator = '';
   if (state.agentLanes.length > 0) {
     const lines = state.agentLanes
@@ -368,10 +235,6 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
     }
   }
 
-  const seedResult = state.taskSeeding.phase !== 'idle' && state.taskSeeding.message
-    ? `<div class="seed-result ${state.taskSeeding.phase === 'success' ? 'success' : state.taskSeeding.phase === 'error' ? 'error' : ''}">${esc(state.taskSeeding.message)}</div>`
-    : '';
-
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -381,9 +244,8 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style nonce="${nonce}">${buildSidebarCss()}</style>
 </head>
-<body data-mode="simple">
+<body>
 
-  <!-- Header: workspace + loop state -->
   <div class="header">
     <div class="header-title">Ralphdex</div>
     <div class="header-state">
@@ -393,107 +255,20 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
   </div>
 
   ${phaseIndicator}
+  ${state.taskCounts ? buildProgressBar(state.taskCounts) : ''}
 
-  <!-- Mode switcher -->
-  <div class="mode-switcher">
-    <div class="mode-switcher-label">Mode</div>
-    <div class="mode-switcher-pills">
-      <button class="mode-pill active" data-mode="simple">Simple</button>
-      <button class="mode-pill" data-mode="advanced">Advanced</button>
-    </div>
+  <div class="sidebar-status">
+    ${isRunning
+      ? `<div class="sidebar-status-text">Ralph is working — ${esc(stateLabel)}</div>`
+      : `<div class="sidebar-status-text">Ready to start</div>`}
   </div>
 
-  <!-- Progress bar (shown in advanced mode) -->
-  <div class="mode-section mode-advanced">
-    ${buildProgressBar(state.taskCounts)}
+  <div class="sidebar-run-controls">
+    ${isRunning
+      ? `<button class="btn btn-danger" data-command="ralphCodex.stopLoop"><span class="btn-label">■ Stop Loop</span><span class="btn-spinner"></span></button>`
+      : `<button class="btn btn-primary" data-command="ralphCodex.runRalphLoop"><span class="btn-label">▸ Run Loop</span><span class="btn-spinner"></span></button>`}
   </div>
 
-  <!-- Simple mode: start/status at a glance -->
-  <div class="mode-section mode-simple">
-    <div class="simple-status">
-      ${isRunning
-        ? `<div class="simple-status-text">Ralph is working — ${esc(stateLabel)}</div>`
-        : `<div class="simple-status-text">Ready to start</div>`}
-    </div>
-    <div class="btn-grid" style="margin-top: 8px;">
-      ${isRunning
-        ? `<button class="btn btn-danger" data-command="ralphCodex.stopLoop" style="grid-column: 1/-1;"><span class="btn-label">■ Stop Loop</span><span class="btn-spinner"></span></button>`
-        : `<button class="btn btn-primary" data-command="ralphCodex.runRalphLoop" style="grid-column: 1/-1;"><span class="btn-label">▸ Start Loop</span><span class="btn-spinner"></span></button>`}
-      <button class="btn" data-command="ralphCodex.openPrdWizard" style="grid-column: 1/-1;"><span class="btn-label">Open PRD wizard</span><span class="btn-spinner"></span></button>
-    </div>
-  </div>
-
-  <!-- Tab nav (shown in advanced mode) -->
-  <div class="mode-section mode-advanced">
-    <div class="sidebar-tabs">
-      <button class="sidebar-tab active" data-sidebar-tab="run">Run</button>
-      <button class="sidebar-tab" data-sidebar-tab="agents">Agents</button>
-      <button class="sidebar-tab" data-sidebar-tab="seed">Seed</button>
-    </div>
-  </div>
-
-  <!-- Run tab panel -->
-  <div class="sidebar-tab-panel active mode-section mode-advanced" data-sidebar-panel="run">
-    <div class="section-label">Loop Controls</div>
-    <div class="btn-grid">
-      <button class="btn" data-command="ralphCodex.runRalphLoop"><span class="btn-label">▸ Run Loop</span><span class="btn-spinner"></span></button>
-      <button class="btn" data-command="ralphCodex.runMultiAgentLoop"><span class="btn-label">▸ Multi</span><span class="btn-spinner"></span></button>
-      <button class="btn" data-command="ralphCodex.runRalphIteration"><span class="btn-label">▸ Iteration</span><span class="btn-spinner"></span></button>
-    </div>
-
-    <div class="section-label" style="margin-top: 10px;">Prepare &amp; Inspect</div>
-    <div class="quick-actions">
-      <button class="quick-action" data-command="ralphCodex.generatePrompt">
-        <span>Prepare Prompt</span><span class="quick-shortcut">⎙</span>
-      </button>
-      <button class="quick-action" data-command="ralphCodex.showRalphStatus">
-        <span>Show Status</span><span class="quick-shortcut">◫</span>
-      </button>
-      <button class="quick-action" data-command="ralphCodex.showTasks">
-        <span>Open Tasks</span><span class="quick-shortcut">⌘T</span>
-      </button>
-      <button class="quick-action" data-command="ralphCodex.openLatestPipelineRun">
-        <span>Latest Run</span><span class="quick-shortcut">◫</span>
-      </button>
-      <button class="quick-action" data-command="ralphCodex.openSettings">
-        <span>Settings</span><span class="quick-shortcut">⌘,</span>
-      </button>
-    </div>
-
-    <!-- Advanced-only actions -->
-    <div class="mode-section mode-advanced">
-      <div class="section-label" style="margin-top: 10px;">Advanced</div>
-      <div class="btn-grid">
-        <button class="btn" data-command="ralphCodex.openPrdWizard"><span class="btn-label">PRD Wizard</span><span class="btn-spinner"></span></button>
-        <button class="btn" data-command="ralphCodex.openLatestProvenanceBundle"><span class="btn-label">Provenance</span><span class="btn-spinner"></span></button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Agents tab panel -->
-  <div class="sidebar-tab-panel mode-section mode-advanced" data-sidebar-panel="agents">
-    <div class="section-label">Agent Roles</div>
-    <div class="btn-grid">
-      <button class="btn" data-command="ralphCodex.runRalphLoop"><span class="btn-label">◆ Build</span><span class="btn-spinner"></span></button>
-      <button class="btn" data-command="ralphCodex.runReviewAgent"><span class="btn-label">◇ Review</span><span class="btn-spinner"></span></button>
-      <button class="btn" data-command="ralphCodex.runWatchdogAgent"><span class="btn-label">⬡ Watch</span><span class="btn-spinner"></span></button>
-      <button class="btn" data-command="ralphCodex.runScmAgent"><span class="btn-label">⎔ SCM</span><span class="btn-spinner"></span></button>
-    </div>
-  </div>
-
-  <!-- Seed tab panel -->
-  <div class="sidebar-tab-panel mode-section mode-advanced" data-sidebar-panel="seed">
-    <div class="seed-block">
-      <textarea data-seed-request="sidebar" placeholder="Describe the epic...">${esc(state.taskSeeding.requestText)}</textarea>
-      <div class="btn-grid" style="margin-top: 8px;">
-        <button class="btn" data-seed-submit="sidebar"><span class="btn-label">Seed Tasks</span><span class="btn-spinner"></span></button>
-        <button class="btn" data-command="ralphCodex.showTasks"><span class="btn-label">Open Tasks</span><span class="btn-spinner"></span></button>
-      </div>
-      ${seedResult}
-    </div>
-  </div>
-
-  <!-- Current task card (always visible) -->
   ${buildCurrentTaskCard(state)}
 
   <button class="open-dashboard" data-command="ralphCodex.openDashboard">Open Dashboard</button>
@@ -503,39 +278,6 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
       var vscode = acquireVsCodeApi();
       var ackTimeouts = new WeakMap();
 
-      // --- Mode switcher ---
-      var savedMode = (function() {
-        try { return localStorage.getItem('ralph-sidebar-mode') || 'simple'; } catch(e) { return 'simple'; }
-      })();
-      setMode(savedMode);
-
-      document.querySelectorAll('.mode-pill').forEach(function(pill) {
-        pill.addEventListener('click', function() {
-          setMode(pill.getAttribute('data-mode'));
-        });
-      });
-
-      function setMode(mode) {
-        document.body.setAttribute('data-mode', mode);
-        document.querySelectorAll('.mode-pill').forEach(function(p) {
-          p.classList.toggle('active', p.getAttribute('data-mode') === mode);
-        });
-        try { localStorage.setItem('ralph-sidebar-mode', mode); } catch(e) {}
-      }
-
-      // --- Tab nav ---
-      document.querySelectorAll('.sidebar-tab').forEach(function(tab) {
-        tab.addEventListener('click', function() {
-          var target = tab.getAttribute('data-sidebar-tab');
-          document.querySelectorAll('.sidebar-tab').forEach(function(t) { t.classList.remove('active'); });
-          document.querySelectorAll('.sidebar-tab-panel').forEach(function(p) { p.classList.remove('active'); });
-          tab.classList.add('active');
-          var panel = document.querySelector('[data-sidebar-panel="' + target + '"]');
-          if (panel) panel.classList.add('active');
-        });
-      });
-
-      // --- Command buttons ---
       function runCommand(el) {
         var cmd = el.getAttribute('data-command');
         if (!cmd || el.disabled) return;
@@ -553,21 +295,7 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
         if (t) { clearTimeout(t); ackTimeouts.delete(el); }
       }
 
-      function runSeedTasks(el) {
-        var source = el.getAttribute('data-seed-submit');
-        if (!source || el.disabled) return;
-        var field = document.querySelector('[data-seed-request="' + source + '"]');
-        var requestText = field ? field.value : '';
-        el.classList.add('loading');
-        el.disabled = true;
-        vscode.postMessage({ type: 'seed-tasks', requestText: requestText, source: source });
-        var t = setTimeout(function() { resetButton(el); }, 15000);
-        ackTimeouts.set(el, t);
-      }
-
       document.addEventListener('click', function(e) {
-        var seedBtn = e.target.closest('[data-seed-submit]');
-        if (seedBtn) { runSeedTasks(seedBtn); return; }
         var btn = e.target.closest('[data-command]');
         if (btn) { runCommand(btn); }
       });
@@ -583,14 +311,6 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
         if (msg.type === 'command-ack') {
           var btns = document.querySelectorAll('[data-command="' + msg.command + '"]');
           btns.forEach(function(btn) {
-            if (msg.status === 'done' || msg.status === 'error') {
-              resetButton(btn);
-            }
-          });
-        }
-        if (msg.type === 'seed-tasks-result') {
-          var seedButtons = document.querySelectorAll('[data-seed-submit="' + msg.source + '"]');
-          seedButtons.forEach(function(btn) {
             if (msg.status === 'done' || msg.status === 'error') {
               resetButton(btn);
             }

--- a/src/ui/taskTreeView.ts
+++ b/src/ui/taskTreeView.ts
@@ -53,7 +53,7 @@ class TaskGroupItem extends TaskTreeNode {
         label = 'Done';
         state = vscode.TreeItemCollapsibleState.Collapsed;
         break;
-      case 'dead-letter': label = 'Dead-Letter Queue'; break;
+      case 'dead-letter': label = 'Recovery Queue'; break;
     }
     super(label, state);
     this.description = String(count);
@@ -113,7 +113,7 @@ function describeTask(input: {
   const parts: string[] = [];
 
   if (input.groupKind === 'dead-letter') {
-    parts.push('dead-letter');
+    parts.push('recovery queue');
   }
 
   if (input.task) {
@@ -240,7 +240,7 @@ export class RalphTaskTreeDataProvider implements vscode.TreeDataProvider<TaskTr
 
   private buildDeadLetterRows(snapshot: TaskTreeSnapshot): TaskTreeNode[] {
     if (snapshot.deadLetterOrder.length === 0) {
-      return [new MessageItem('No tasks are parked in dead-letter.')];
+      return [new MessageItem('No tasks are parked in the recovery queue.')];
     }
 
     return snapshot.deadLetterOrder.map((taskId) => {
@@ -344,15 +344,15 @@ export class RalphTaskTreeDataProvider implements vscode.TreeDataProvider<TaskTr
     if (deadLetterEntry) {
       const lastDiagnostic = deadLetterEntry.diagnosticHistory[deadLetterEntry.diagnosticHistory.length - 1];
       details.push(new DetailItem(
-        'Dead-letter summary',
+        'Recovery summary',
         `${deadLetterEntry.deadLetteredAt} | attempts: ${deadLetterEntry.recoveryAttemptCount}${lastDiagnostic ? ` | last: ${lastDiagnostic.rootCauseCategory}` : ''}`
       ));
       details.push(new DetailItem(
-        'Requeue dead-letter task',
+        'Requeue recovery task',
         'Run the supported requeue command.',
         {
           command: 'ralphCodex.requeueDeadLetterTask',
-          title: 'Requeue Dead-Letter Task'
+          title: 'Requeue Recovery Task'
         }
       ));
     }

--- a/test/taskTreeView.test.ts
+++ b/test/taskTreeView.test.ts
@@ -29,7 +29,7 @@ test.beforeEach(() => {
   vscodeTestHarness().reset();
 });
 
-test('task tree provider separates active and dead-letter tasks and surfaces artifact-backed details', async () => {
+test('task tree provider separates active and recovery-queue tasks and surfaces artifact-backed details', async () => {
   const rootPath = await makeTempRoot();
   const ralphDir = path.join(rootPath, '.ralph');
   const artifactsDir = path.join(ralphDir, 'artifacts');
@@ -53,7 +53,7 @@ test('task tree provider separates active and dead-letter tasks and surfaces art
       },
       {
         id: 'T2',
-        title: 'Recover dead-letter task',
+        title: 'Recover parked task',
         status: 'blocked',
         blocker: 'Needs operator requeue'
       }
@@ -79,7 +79,7 @@ test('task tree provider separates active and dead-letter tasks and surfaces art
         schemaVersion: 1,
         kind: 'deadLetterEntry',
         taskId: 'T2',
-        taskTitle: 'Recover dead-letter task',
+        taskTitle: 'Recover parked task',
         deadLetteredAt: '2026-04-12T10:00:00.000Z',
         recoveryAttemptCount: 3,
         diagnosticHistory: [
@@ -135,9 +135,9 @@ test('task tree provider separates active and dead-letter tasks and surfaces art
   assert.equal(rootItems.length, 5);
 
   const todoGroup = rootItems.find((item: TreeItemLike) => item.label === 'To Do');
-  const deadLetterGroup = rootItems.find((item: TreeItemLike) => item.label === 'Dead-Letter Queue');
+  const recoveryGroup = rootItems.find((item: TreeItemLike) => item.label === 'Recovery Queue');
   assert.ok(todoGroup);
-  assert.ok(deadLetterGroup);
+  assert.ok(recoveryGroup);
 
   const activeTasks = await provider.getChildren(todoGroup);
   assert.equal(activeTasks.length, 1);
@@ -154,14 +154,26 @@ test('task tree provider separates active and dead-letter tasks and surfaces art
   assert.ok(staleClaimAction);
   assert.equal(staleClaimAction?.command?.command, 'ralphCodex.resolveStaleTaskClaim');
 
-  const deadLetterTasks = await provider.getChildren(deadLetterGroup);
-  assert.equal(deadLetterTasks.length, 1);
-  assert.equal(deadLetterTasks[0]?.label, 'T2');
-  assert.match(String(deadLetterTasks[0]?.description ?? ''), /dead-letter/);
+  const recoveryTasks = await provider.getChildren(recoveryGroup);
+  assert.equal(recoveryTasks.length, 1);
+  assert.equal(recoveryTasks[0]?.label, 'T2');
+  assert.match(String(recoveryTasks[0]?.description ?? ''), /recovery queue/);
 
-  const deadLetterDetails = await provider.getChildren(deadLetterTasks[0]);
-  assert.ok(deadLetterDetails.some((item: TreeItemLike) => item.label === 'Dead-letter summary'));
-  const requeueAction = deadLetterDetails.find((item: TreeItemLike) => item.label === 'Requeue dead-letter task');
+  const recoveryDetails = await provider.getChildren(recoveryTasks[0]);
+  assert.ok(recoveryDetails.some((item: TreeItemLike) => item.label === 'Recovery summary'));
+  const requeueAction = recoveryDetails.find((item: TreeItemLike) => item.label === 'Requeue recovery task');
   assert.ok(requeueAction);
   assert.equal(requeueAction?.command?.command, 'ralphCodex.requeueDeadLetterTask');
+  assert.equal(requeueAction?.command?.title, 'Requeue Recovery Task');
+
+  const renderedCopy = [
+    ...rootItems,
+    ...activeTasks,
+    ...activeDetails,
+    ...recoveryTasks,
+    ...recoveryDetails
+  ].map((item: TreeItemLike) => `${String(item.label ?? '')} ${String(item.description ?? '')} ${item.command?.title ?? ''}`).join('\n');
+  assert.ok(!renderedCopy.includes('Dead-Letter'));
+  assert.ok(!renderedCopy.includes('Dead-letter'));
+  assert.ok(!renderedCopy.includes('dead-letter'));
 });

--- a/test/ui/sidebarHtml.test.ts
+++ b/test/ui/sidebarHtml.test.ts
@@ -131,29 +131,38 @@ test('buildDashboardHtml shows phase indicator when running', () => {
   assert.ok(html.includes('execute'));
 });
 
-test('buildDashboardHtml keeps all buttons enabled during running state for parallel launches', () => {
+test('buildDashboardHtml keeps compact sidebar buttons enabled during running state', () => {
   const html = buildDashboardHtml(defaultState({ loopState: 'running' }), 'n5');
-  // Sidebar buttons stay enabled — claims handle contention.
   const disabledButtons = (html.match(/<button[^>]*disabled[^>]*>/g) ?? []).length;
   assert.equal(disabledButtons, 0, `Expected 0 disabled buttons, got ${disabledButtons}`);
 });
 
-test('buildDashboardHtml renders agent and action button grids', () => {
-  const html = buildDashboardHtml(defaultState(), 'n6');
-  assert.ok(html.includes('ralphCodex.runRalphLoop'));
-  assert.ok(html.includes('ralphCodex.runReviewAgent'));
-  assert.ok(html.includes('ralphCodex.runWatchdogAgent'));
-  assert.ok(html.includes('ralphCodex.runScmAgent'));
-  assert.ok(html.includes('ralphCodex.runRalphIteration'));
-  assert.ok(html.includes('ralphCodex.generatePrompt'));
-  assert.ok(html.includes('ralphCodex.openPrdWizard'));
-  assert.ok(!html.includes('ralphCodex.initializeWorkspace'));
+test('buildDashboardHtml keeps sidebar focused on compact run and dashboard navigation', () => {
+  const html = buildDashboardHtml(defaultState(), 'sidebar-actions');
+
+  assert.ok(html.includes('data-command="ralphCodex.runRalphLoop"'));
+  assert.ok(html.includes('data-command="ralphCodex.openDashboard"'));
+  assert.ok(html.includes('Run Loop'));
+  assert.ok(html.includes('Open Dashboard'));
+
+  assert.ok(!html.includes('ralphCodex.runMultiAgentLoop'));
+  assert.ok(!html.includes('ralphCodex.runRalphIteration'));
+  assert.ok(!html.includes('ralphCodex.runReviewAgent'));
+  assert.ok(!html.includes('ralphCodex.runWatchdogAgent'));
+  assert.ok(!html.includes('ralphCodex.runScmAgent'));
+  assert.ok(!html.includes('ralphCodex.generatePrompt'));
+  assert.ok(!html.includes('ralphCodex.openPrdWizard'));
+  assert.ok(!html.includes('ralphCodex.showTasks'));
+  assert.ok(!html.includes('ralphCodex.openLatestPipelineRun'));
+  assert.ok(!html.includes('ralphCodex.openSettings'));
 });
 
-test('buildDashboardHtml includes Open Dashboard button', () => {
-  const html = buildDashboardHtml(defaultState(), 'n7');
-  assert.ok(html.includes('ralphCodex.openDashboard'));
-  assert.ok(html.includes('Open Dashboard'));
+test('buildDashboardHtml renders stop control when loop is running', () => {
+  const html = buildDashboardHtml(defaultState({ loopState: 'running' }), 'running-actions');
+
+  assert.ok(html.includes('data-command="ralphCodex.stopLoop"'));
+  assert.ok(html.includes('Stop Loop'));
+  assert.ok(!html.includes('data-command="ralphCodex.runRalphLoop"'));
 });
 
 test('buildDashboardHtml renders header with workspace name and state', () => {
@@ -169,92 +178,40 @@ test('buildDashboardHtml includes command-ack message handler', () => {
   assert.ok(html.includes('resetButton'));
 });
 
-test('buildDashboardHtml renders sidebar task-seeding affordance and latest result copy', () => {
-  const html = buildDashboardHtml(defaultState({
-    taskSeeding: {
-      phase: 'success',
-      requestText: 'Seed a sidebar epic',
-      createdTaskCount: 4,
-      message: 'Seeded 4 task(s).',
-      artifactPath: '.ralph/artifacts/task-seeding/sidebar.json'
-    }
-  }), 'seed-sidebar');
+test('buildDashboardHtml omits sidebar task-seeding hooks because seeding belongs in dashboard/tasks flow', () => {
+  const html = buildDashboardHtml(defaultState(), 'seed-sidebar');
 
-  assert.ok(html.includes('Seed Tasks'));
-  assert.ok(html.includes('data-seed-request'));
-  assert.ok(html.includes("type: 'seed-tasks'"));
-  assert.ok(html.includes('Seeded 4 task(s).'));
-  assert.ok(html.includes('ralphCodex.showTasks'));
+  assert.ok(!html.includes('Seed Tasks'));
+  assert.ok(!html.includes('data-seed-request'));
+  assert.ok(!html.includes("type: 'seed-tasks'"));
+  assert.ok(!html.includes('data-seed-submit'));
 });
 
-test('buildDashboardHtml preserves live status, orchestration, task, and settings shortcuts', () => {
-  const html = buildDashboardHtml(defaultState(), 'sidebar-actions');
-
-  assert.ok(html.includes('Loop Controls'));
-  assert.ok(html.includes('Prepare &amp; Inspect'));
-  assert.ok(html.includes('ralphCodex.showRalphStatus'));
-  assert.ok(!html.includes('ralphCodex.showMultiAgentStatus'));
-  assert.ok(html.includes('ralphCodex.generatePrompt'));
-  assert.ok(html.includes('ralphCodex.showTasks'));
-  assert.ok(html.includes('ralphCodex.openLatestPipelineRun'));
-  assert.ok(html.includes('ralphCodex.openSettings'));
-  assert.ok(html.includes('ralphCodex.openDashboard'));
-});
-
-test('buildDashboardHtml exposes Open PRD wizard in simple mode with the existing command binding', () => {
-  const html = buildDashboardHtml(defaultState(), 'simple-prd-wizard');
-
-  assert.ok(html.includes('Open PRD wizard'));
-  assert.ok(html.includes('data-command="ralphCodex.openPrdWizard"'));
-});
-
-test('buildDashboardHtml omits orchestration tab wiring from sidebar navigation', () => {
+test('buildDashboardHtml omits sidebar tab navigation and advanced orchestration controls', () => {
   const html = buildDashboardHtml(defaultState(), 'sidebar-tabs');
 
-  assert.ok(html.includes('data-sidebar-tab="run"'));
-  assert.ok(html.includes('data-sidebar-tab="agents"'));
-  assert.ok(html.includes('data-sidebar-tab="seed"'));
-  assert.ok(!html.includes('data-sidebar-tab="orchestration"'));
+  assert.ok(!html.includes('data-sidebar-tab="run"'));
+  assert.ok(!html.includes('data-sidebar-tab="agents"'));
+  assert.ok(!html.includes('data-sidebar-tab="seed"'));
   assert.ok(!html.includes('data-sidebar-panel="orchestration"'));
   assert.ok(!html.includes('>Orchestration<'));
+  assert.ok(!html.includes('Agent Roles'));
+  assert.ok(!html.includes('Prepare &amp; Inspect'));
 });
 
-test('buildDashboardHtml keeps refreshed sidebar routing bound to live commands and typed seed-task hooks', () => {
-  const html = buildDashboardHtml(defaultState({
-    taskSeeding: {
-      phase: 'submitting',
-      requestText: 'Seed the refreshed dashboard regression contract',
-      createdTaskCount: null,
-      message: 'Seeding tasks from sidebar request...',
-      artifactPath: null
-    }
-  }), 'sidebar-routing');
-
-  assert.ok(html.includes('data-command="ralphCodex.runRalphLoop"'));
-  assert.ok(html.includes('data-command="ralphCodex.runMultiAgentLoop"'));
-  assert.ok(html.includes('data-command="ralphCodex.runRalphIteration"'));
-  assert.ok(html.includes('data-command="ralphCodex.showRalphStatus"'));
-  assert.ok(!html.includes('data-command="ralphCodex.showMultiAgentStatus"'));
-  assert.ok(html.includes('data-command="ralphCodex.openLatestPipelineRun"'));
-  assert.ok(html.includes('data-command="ralphCodex.openSettings"'));
-  assert.ok(html.includes('data-command="ralphCodex.showTasks"'));
-  assert.ok(html.includes('data-command="ralphCodex.openDashboard"'));
-  assert.ok(html.includes('data-seed-request="sidebar"'));
-  assert.ok(html.includes('data-seed-submit="sidebar"'));
-  assert.ok(html.includes("vscode.postMessage({ type: 'seed-tasks', requestText: requestText, source: source })"));
-  assert.ok(html.includes("document.querySelectorAll('[data-seed-submit=\"' + msg.source + '\"]')"));
-});
-
-test('buildDashboardHtml surfaces live durable snapshot summary signals in the refreshed sidebar', () => {
+test('buildDashboardHtml surfaces live durable snapshot summary signals with recovery queue language', () => {
   const html = buildDashboardHtml(defaultState({
     dashboardSnapshot: populatedDashboardSnapshot()
   }), 'sidebar-snapshot');
 
+  assert.ok(html.includes('Current Work'));
   assert.ok(html.includes('Selected T110'));
   assert.ok(html.includes('Surface dashboard sections'));
   assert.ok(html.includes('Blocked 1'));
-  assert.ok(html.includes('Dead-Letter 1'));
+  assert.ok(html.includes('Recovery Queue 1'));
   assert.ok(html.includes('validation_mismatch'));
-  assert.ok(html.includes('Recover failed task'));
+  assert.ok(html.includes('Recovery: Recover failed task'));
   assert.ok(html.includes('agent-alpha'));
+  assert.ok(!html.includes('Dead-Letter'));
+  assert.ok(!html.includes('Dead-letter'));
 });


### PR DESCRIPTION
## Summary

Implementation work for Issues #38 and #41 using the UX surface contract from Issue #37 / PR #45.

### Current changes

- Simplifies the RalphDex sidebar into a compact operator surface:
  - run/stop control
  - progress summary
  - current work snapshot
  - open dashboard CTA
- Removes rich/duplicated sidebar controls for:
  - multi-agent loop
  - single iteration
  - review/watchdog/SCM agents
  - prepare/inspect shortcuts
  - task seeding form
  - settings shortcut
  - PRD wizard shortcut
- Replaces sidebar dead-letter copy with Recovery Queue language while preserving internal state names and command IDs.
- Replaces task-tree user-facing dead-letter labels with Recovery Queue / recovery-task language while preserving `dead-letter` internal group keys and `ralphCodex.requeueDeadLetterTask` command ID.
- Updates sidebar and task-tree tests to assert the compact surface contract and stale-language expectations.

## Scope

This PR intentionally preserves command IDs, internal artifact names, schema names, and durable file paths. It is focused on user-facing surface ownership and visible copy.

## Issues

Covers implementation pass for:

- #38
- #41

## Testing

Not run yet in this environment. Recommended local checks:

```bash
npm run compile:tests
node --require ./test/register-vscode-stub.cjs --test ./out-test/test/ui/sidebarHtml.test.js ./out-test/test/taskTreeView.test.js
npm run check:docs
```

Before merge, prefer:

```bash
npm run validate
```

## Remaining work before ready

- Check dashboard copy for remaining user-facing `dead-letter`, `pipeline`, and `prepare prompt` references.
- Consider whether command-palette labels in `package.json` should be renamed now or left to a smaller follow-up to reduce blast radius.
- Update this PR testing section with actual local results.