### PR TITLE
Add GitHub Actions validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run validation gate
+        run: npm run validate


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow for RalphDex validation.

## What it does

- Runs on pull requests targeting `main`.
- Runs on pushes to `main`.
- Supports manual `workflow_dispatch` runs.
- Uses read-only repository permissions.
- Cancels superseded runs on the same ref.
- Installs dependencies with `npm ci`.
- Runs the existing authoritative validation gate:

```bash
npm run validate
```

## Node version

The workflow uses Node.js 24.

Rationale:

- The repo currently allows `node >=20`.
- Node 20 is no longer a good CI target because it has reached end of life.
- Node 24 is the current LTS line and is a better default CI/runtime target for forward validation.
- This PR does not change `package.json` engine metadata; it only chooses the CI runner runtime.

## Scope

This PR adds one workflow file only:

- `.github/workflows/ci.yml`

It does not alter package scripts, runtime metadata, test implementation, or release behavior.

## Testing

Not run locally in this environment. The workflow itself should run once this PR is opened.