### PR TITLE
Route no-PRD sidebar starts through readiness

### DIFF
--- a/src/ui/sidebarHtml.ts
+++ b/src/ui/sidebarHtml.ts
@@ -68,6 +68,13 @@ body {
   border-color: color-mix(in srgb, var(--bad) 40%, var(--border));
 }
 
+.btn-setup {
+  background: color-mix(in srgb, var(--warn) 18%, transparent);
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 48%, var(--border));
+  font-weight: 600;
+}
+
 .btn-spinner {
   display: none;
   width: 10px;
@@ -150,6 +157,10 @@ body {
   color: var(--dim);
 }
 
+.sidebar-status-text.warn {
+  color: var(--warn);
+}
+
 .open-dashboard {
   display: block;
   width: 100%;
@@ -202,6 +213,14 @@ function buildCurrentTaskCard(state: RalphDashboardState): string {
   const blockedCount = taskBoard?.counts?.blocked ?? 0;
   const recoveryCount = taskBoard?.deadLetterCount ?? 0;
 
+  if (!state.prdExists && !id && !taskBoard) {
+    return `<div class="current-task-card blocked">
+      <div class="current-task-kicker">Setup Required</div>
+      <div class="current-task-title">Create a PRD before running RalphDex.</div>
+      <div class="current-task-meta">The PRD wizard will create the objective and starting backlog.</div>
+    </div>`;
+  }
+
   return `<div class="current-task-card${blockedCount > 0 || recoveryCount > 0 ? ' blocked' : ''}">
     <div class="current-task-kicker">Current Work</div>
     ${id ? `<div class="current-task-id">Selected ${esc(id)}</div>` : ''}
@@ -216,6 +235,34 @@ function buildCurrentTaskCard(state: RalphDashboardState): string {
     ${agentRow ? `<div class="current-task-meta">${esc(agentRow.agentId)}</div>` : ''}
     ${!id && !taskBoard ? '<div class="current-task-empty">No task selected</div>' : ''}
   </div>`;
+}
+
+function buildRunControl(state: RalphDashboardState): string {
+  if (state.loopState === 'running') {
+    return `<button class="btn btn-danger" data-command="ralphCodex.stopLoop"><span class="btn-label">■ Stop Loop</span><span class="btn-spinner"></span></button>`;
+  }
+
+  if (!state.prdExists) {
+    return `<button class="btn btn-setup" data-command="ralphCodex.openPrdWizard"><span class="btn-label">Open PRD Wizard</span><span class="btn-spinner"></span></button>`;
+  }
+
+  return `<button class="btn btn-primary" data-command="ralphCodex.runRalphLoop"><span class="btn-label">▸ Run Loop</span><span class="btn-spinner"></span></button>`;
+}
+
+function buildSidebarStatusText(state: RalphDashboardState, stateLabel: string): string {
+  if (state.loopState === 'running') {
+    return `<div class="sidebar-status-text">Ralph is working — ${esc(stateLabel)}</div>`;
+  }
+
+  if (!state.prdExists) {
+    return '<div class="sidebar-status-text warn">PRD required before running</div>';
+  }
+
+  if (!state.preflightReady) {
+    return `<div class="sidebar-status-text warn">Readiness blocked — ${esc(state.preflightSummary)}</div>`;
+  }
+
+  return '<div class="sidebar-status-text">Ready to start</div>';
 }
 
 export function buildDashboardHtml(state: RalphDashboardState, nonce: string): string {
@@ -258,15 +305,11 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
   ${state.taskCounts ? buildProgressBar(state.taskCounts) : ''}
 
   <div class="sidebar-status">
-    ${isRunning
-      ? `<div class="sidebar-status-text">Ralph is working — ${esc(stateLabel)}</div>`
-      : `<div class="sidebar-status-text">Ready to start</div>`}
+    ${buildSidebarStatusText(state, stateLabel)}
   </div>
 
   <div class="sidebar-run-controls">
-    ${isRunning
-      ? `<button class="btn btn-danger" data-command="ralphCodex.stopLoop"><span class="btn-label">■ Stop Loop</span><span class="btn-spinner"></span></button>`
-      : `<button class="btn btn-primary" data-command="ralphCodex.runRalphLoop"><span class="btn-label">▸ Run Loop</span><span class="btn-spinner"></span></button>`}
+    ${buildRunControl(state)}
   </div>
 
   ${buildCurrentTaskCard(state)}
@@ -285,7 +328,7 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
         el.disabled = true;
         vscode.postMessage({ type: 'command', command: cmd });
         var t = setTimeout(function() { resetButton(el); }, 10000);
-        ackTimeouts.set(el, t);
+        ackTimeouts.set(el);
       }
 
       function resetButton(el) {

--- a/src/ui/sidebarHtml.ts
+++ b/src/ui/sidebarHtml.ts
@@ -328,7 +328,7 @@ export function buildDashboardHtml(state: RalphDashboardState, nonce: string): s
         el.disabled = true;
         vscode.postMessage({ type: 'command', command: cmd });
         var t = setTimeout(function() { resetButton(el); }, 10000);
-        ackTimeouts.set(el);
+        ackTimeouts.set(el, t);
       }
 
       function resetButton(el) {

--- a/test/ui/sidebarHtml.test.ts
+++ b/test/ui/sidebarHtml.test.ts
@@ -23,7 +23,7 @@ function defaultState(overrides: Partial<RalphDashboardState> = {}): RalphDashbo
     snapshotStatus: { phase: 'idle', errorMessage: null },
     taskSeeding: { phase: 'idle', requestText: '', createdTaskCount: null, message: null, artifactPath: null },
     viewIntent: null,
-    prdExists: false,
+    prdExists: true,
     ...overrides
   };
 }
@@ -137,7 +137,7 @@ test('buildDashboardHtml keeps compact sidebar buttons enabled during running st
   assert.equal(disabledButtons, 0, `Expected 0 disabled buttons, got ${disabledButtons}`);
 });
 
-test('buildDashboardHtml keeps sidebar focused on compact run and dashboard navigation', () => {
+test('buildDashboardHtml keeps sidebar focused on compact run and dashboard navigation when ready', () => {
   const html = buildDashboardHtml(defaultState(), 'sidebar-actions');
 
   assert.ok(html.includes('data-command="ralphCodex.runRalphLoop"'));
@@ -151,10 +151,31 @@ test('buildDashboardHtml keeps sidebar focused on compact run and dashboard navi
   assert.ok(!html.includes('ralphCodex.runWatchdogAgent'));
   assert.ok(!html.includes('ralphCodex.runScmAgent'));
   assert.ok(!html.includes('ralphCodex.generatePrompt'));
-  assert.ok(!html.includes('ralphCodex.openPrdWizard'));
   assert.ok(!html.includes('ralphCodex.showTasks'));
   assert.ok(!html.includes('ralphCodex.openLatestPipelineRun'));
   assert.ok(!html.includes('ralphCodex.openSettings'));
+});
+
+test('buildDashboardHtml routes no-PRD sidebar start to the PRD wizard instead of loop execution', () => {
+  const html = buildDashboardHtml(defaultState({ prdExists: false }), 'no-prd-sidebar');
+
+  assert.ok(html.includes('PRD required before running'));
+  assert.ok(html.includes('Setup Required'));
+  assert.ok(html.includes('Create a PRD before running RalphDex.'));
+  assert.ok(html.includes('data-command="ralphCodex.openPrdWizard"'));
+  assert.ok(html.includes('Open PRD Wizard'));
+  assert.ok(!html.includes('data-command="ralphCodex.runRalphLoop"'));
+});
+
+test('buildDashboardHtml shows preflight readiness block without replacing PRD-ready run command', () => {
+  const html = buildDashboardHtml(defaultState({
+    prdExists: true,
+    preflightReady: false,
+    preflightSummary: 'Provider command not found.'
+  }), 'preflight-sidebar');
+
+  assert.ok(html.includes('Readiness blocked — Provider command not found.'));
+  assert.ok(html.includes('data-command="ralphCodex.runRalphLoop"'));
 });
 
 test('buildDashboardHtml renders stop control when loop is running', () => {
@@ -176,6 +197,7 @@ test('buildDashboardHtml includes command-ack message handler', () => {
   const html = buildDashboardHtml(defaultState(), 'n9');
   assert.ok(html.includes('command-ack'));
   assert.ok(html.includes('resetButton'));
+  assert.ok(html.includes('ackTimeouts.set(el, t)'));
 });
 
 test('buildDashboardHtml omits sidebar task-seeding hooks because seeding belongs in dashboard/tasks flow', () => {


### PR DESCRIPTION
## Summary

Starts implementation for #39 by making the compact sidebar readiness-safe when no PRD/objective exists.

## Changes

- When `prdExists` is false, the sidebar primary action now opens the PRD wizard instead of exposing `ralphCodex.runRalphLoop`.
- Adds no-PRD setup copy in the sidebar:
  - `PRD required before running`
  - `Setup Required`
  - `Create a PRD before running RalphDex.`
- Keeps stop behavior available while a loop is running.
- Keeps the ready-state sidebar path unchanged when a PRD exists.
- Preserves the existing command IDs and webview command bridge behavior.
- Fixes the sidebar command-ACK timeout storage while touching this path.
- Updates sidebar renderer tests to cover:
  - no-PRD route to `ralphCodex.openPrdWizard`
  - absence of `ralphCodex.runRalphLoop` in no-PRD sidebar state
  - PRD-ready route still exposing `ralphCodex.runRalphLoop`
  - command ACK timeout registration
  - existing compact-surface constraints from #38

## Scope

This PR intentionally limits the first implementation slice to the visible compact sidebar start path.

The command layer already contains a shared `ensureRealPrdOrOpenWizard(...)` helper intended to guard provider execution paths. I did not broaden this PR into a large command-registration rewrite via the connector because `src/commands/registerCommands.ts` is large and not safely editable here without full local validation.

## Issue coverage

Partial implementation for #39.

Still required before #39 can close:

- Verify command-palette execution paths for:
  - `ralphCodex.runRalphIteration`
  - `ralphCodex.runRalphLoop`
  - `ralphCodex.runMultiAgentLoop`
  - `ralphCodex.runPipeline`
  - `ralphCodex.generatePrompt`
  - `ralphCodex.openCodexAndCopyPrompt`
- Add or confirm tests proving no-PRD command-palette start attempts route through the PRD wizard/readiness guard.
- Check dashboard start controls and seed/decompose states for no-PRD and PRD-exists/no-tasks branches.

## Testing

Not run in this environment. Recommended local checks:

```bash
npm run compile:tests
node --require ./test/register-vscode-stub.cjs --test ./out-test/test/ui/sidebarHtml.test.js
npm run validate
```
