### PR TITLE
Harden completion report JSON extraction

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -208,6 +208,8 @@ The CLI provenance chain proves prompt integrity up to the `codex exec` boundary
 
 The completion report is a model's self-report. It is labelled as unverified in the run bundle. The field name `completionReportStatus` and the bundle's explicit `epistemicGap.modelClaims*` fields make that epistemic status machine-readable so downstream tooling can distinguish verified evidence from model assertion.
 
+Completion report extraction remains strict JSON, not JSONC: fenced `json` reports are preferred, `JSON.parse` is the authority for the extracted object, and comments or prose inside the object are invalid. If a fenced report contains one balanced JSON object followed by extra prose after the closing brace, Ralph ignores only that trailing text and records a parser warning.
+
 `reconciliationWarnings` records cases where the model's claimed status diverged from what preflight and verifier evidence found. A warning entry means an inconsistency was detected and surfaced; the absence of warnings means the model's claimed status was consistent with the observable verifier signals. Absence of reconciliation warnings does not prove the model's reasoning was correct — it proves only that the model's claimed status was consistent with those observable signals.
 
 Operators requiring stronger guarantees should treat the verifier artifacts — `validationCommand`, `gitDiff`, and `taskState`, surfaced through `execution-summary.json`, `verifier-summary.json`, and `iteration-result.json` — as the authoritative evidence and treat the completion report as supplementary context. Those artifacts are produced from observable outcomes, not from the model's self-description.

--- a/src/ralph/completionReportParser.ts
+++ b/src/ralph/completionReportParser.ts
@@ -251,6 +251,7 @@ function parseWatchdogActions(candidate: unknown): RalphWatchdogAction[] | undef
 interface ExtractedJsonObject {
   objectText: string;
   ignoredTrailingContent: boolean;
+  ambiguousTrailingJsonObject: boolean;
 }
 
 function extractBalancedJsonObjectFromBlock(block: string): ExtractedJsonObject | null {
@@ -293,9 +294,11 @@ function extractBalancedJsonObjectFromBlock(block: string): ExtractedJsonObject 
       if (depth === 0) {
         const objectText = block.slice(start, i + 1).trim();
         const trailing = block.slice(i + 1);
+        const trimmedTrailing = trailing.trimStart();
         return {
           objectText,
-          ignoredTrailingContent: trailing.trim().length > 0
+          ignoredTrailingContent: trailing.trim().length > 0,
+          ambiguousTrailingJsonObject: trimmedTrailing.startsWith('{')
         };
       }
       if (depth < 0) {
@@ -393,10 +396,18 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
   if (fencedMatch?.[1] !== undefined) {
     // Fenced reports are the preferred contract. Deterministically accept the
     // first balanced object in the fence only when it starts the JSON block;
-    // anything after that object is ignored with a warning rather than used to
-    // guess between multiple candidate objects. JSON.parse below remains the
-    // authority for whether the extracted object is strict JSON.
+    // trailing prose is tolerated, but a second object is ambiguous and invalid.
+    // JSON.parse below remains the authority for whether the extracted object is strict JSON.
     const extracted = extractBalancedJsonObjectFromBlock(fencedMatch[1]);
+    if (extracted?.ambiguousTrailingJsonObject) {
+      return {
+        status: 'invalid',
+        report: null,
+        rawBlock: fencedMatch[1].trim(),
+        parseError: 'Completion report contains multiple JSON objects in the fenced block.',
+        warnings: []
+      };
+    }
     rawBlock = extracted?.objectText ?? fencedMatch[1].trim();
     if (extracted?.ignoredTrailingContent) {
       warnings.push('Ignored trailing content after completion report JSON object.');

--- a/src/ralph/completionReportParser.ts
+++ b/src/ralph/completionReportParser.ts
@@ -248,6 +248,65 @@ function parseWatchdogActions(candidate: unknown): RalphWatchdogAction[] | undef
     .filter((action): action is RalphWatchdogAction => action !== null);
 }
 
+interface ExtractedJsonObject {
+  objectText: string;
+  ignoredTrailingContent: boolean;
+}
+
+function extractBalancedJsonObjectFromBlock(block: string): ExtractedJsonObject | null {
+  const leadingWhitespaceLength = block.length - block.trimStart().length;
+  const start = leadingWhitespaceLength;
+  if (block[start] !== '{') {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < block.length; i += 1) {
+    const char = block[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === '{') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        const objectText = block.slice(start, i + 1).trim();
+        const trailing = block.slice(i + 1);
+        return {
+          objectText,
+          ignoredTrailingContent: trailing.trim().length > 0
+        };
+      }
+      if (depth < 0) {
+        return null;
+      }
+    }
+  }
+
+  return null;
+}
+
 export function extractTrailingJsonObject(text: string): string | null {
   const trimmed = text.trimEnd();
   if (!trimmed.endsWith('}')) {
@@ -328,7 +387,24 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
   }
 
   const fencedMatch = /```json\s*([\s\S]*?)\s*```\s*$/i.exec(trimmed);
-  const rawBlock = fencedMatch?.[1]?.trim() ?? extractTrailingJsonObject(trimmed);
+  const warnings: string[] = [];
+  let rawBlock: string | null = null;
+
+  if (fencedMatch?.[1] !== undefined) {
+    // Fenced reports are the preferred contract. Deterministically accept the
+    // first balanced object in the fence only when it starts the JSON block;
+    // anything after that object is ignored with a warning rather than used to
+    // guess between multiple candidate objects. JSON.parse below remains the
+    // authority for whether the extracted object is strict JSON.
+    const extracted = extractBalancedJsonObjectFromBlock(fencedMatch[1]);
+    rawBlock = extracted?.objectText ?? fencedMatch[1].trim();
+    if (extracted?.ignoredTrailingContent) {
+      warnings.push('Ignored trailing content after completion report JSON object.');
+    }
+  } else {
+    rawBlock = extractTrailingJsonObject(trimmed);
+  }
+
   if (!rawBlock) {
     return {
       status: 'missing',
@@ -352,7 +428,7 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
       report: null,
       rawBlock,
       parseError: error instanceof Error ? error.message : String(error),
-      warnings: []
+      warnings
     };
   }
 
@@ -362,7 +438,7 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
       report: null,
       rawBlock,
       parseError: 'Completion report requires a non-empty selectedTaskId string.',
-      warnings: []
+      warnings
     };
   }
   if (typeof candidate.requestedStatus !== 'string' || !isAllowedCompletionStatus(candidate.requestedStatus)) {
@@ -371,7 +447,7 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
       report: null,
       rawBlock,
       parseError: 'Completion report requestedStatus must be one of done, blocked, or in_progress.',
-      warnings: []
+      warnings
     };
   }
   if (candidate.needsHumanReview !== undefined && typeof candidate.needsHumanReview !== 'boolean') {
@@ -380,7 +456,7 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
       report: null,
       rawBlock,
       parseError: 'Completion report needsHumanReview must be a boolean when provided.',
-      warnings: []
+      warnings
     };
   }
   const suggestedChildTasks = parseSuggestedChildTasks(candidate.suggestedChildTasks);
@@ -390,7 +466,7 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
       report: null,
       rawBlock,
       parseError: 'Completion report suggestedChildTasks must be an array of valid suggested child tasks when provided.',
-      warnings: []
+      warnings
     };
   }
   const doctrineUpdates = parseDoctrineUpdatesFromCompletionReport(candidate.doctrineUpdates);
@@ -416,6 +492,6 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
     report,
     rawBlock,
     parseError: null,
-    warnings: doctrineUpdates.warnings
+    warnings: [...warnings, ...doctrineUpdates.warnings]
   };
 }

--- a/src/ralph/completionReportParser.ts
+++ b/src/ralph/completionReportParser.ts
@@ -248,16 +248,19 @@ function parseWatchdogActions(candidate: unknown): RalphWatchdogAction[] | undef
     .filter((action): action is RalphWatchdogAction => action !== null);
 }
 
+interface BalancedJsonObject {
+  objectText: string;
+  endIndex: number;
+}
+
 interface ExtractedJsonObject {
   objectText: string;
   ignoredTrailingContent: boolean;
   ambiguousTrailingJsonObject: boolean;
 }
 
-function extractBalancedJsonObjectFromBlock(block: string): ExtractedJsonObject | null {
-  const leadingWhitespaceLength = block.length - block.trimStart().length;
-  const start = leadingWhitespaceLength;
-  if (block[start] !== '{') {
+function extractBalancedJsonObjectAt(text: string, start: number): BalancedJsonObject | null {
+  if (text[start] !== '{') {
     return null;
   }
 
@@ -265,8 +268,8 @@ function extractBalancedJsonObjectFromBlock(block: string): ExtractedJsonObject 
   let inString = false;
   let escaped = false;
 
-  for (let i = start; i < block.length; i += 1) {
-    const char = block[i];
+  for (let i = start; i < text.length; i += 1) {
+    const char = text[i];
 
     if (inString) {
       if (escaped) {
@@ -292,13 +295,9 @@ function extractBalancedJsonObjectFromBlock(block: string): ExtractedJsonObject 
     if (char === '}') {
       depth -= 1;
       if (depth === 0) {
-        const objectText = block.slice(start, i + 1).trim();
-        const trailing = block.slice(i + 1);
-        const trimmedTrailing = trailing.trimStart();
         return {
-          objectText,
-          ignoredTrailingContent: trailing.trim().length > 0,
-          ambiguousTrailingJsonObject: trimmedTrailing.startsWith('{')
+          objectText: text.slice(start, i + 1).trim(),
+          endIndex: i + 1
         };
       }
       if (depth < 0) {
@@ -308,6 +307,46 @@ function extractBalancedJsonObjectFromBlock(block: string): ExtractedJsonObject 
   }
 
   return null;
+}
+
+function containsLaterStrictJsonObject(text: string): boolean {
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] !== '{') {
+      continue;
+    }
+
+    const extracted = extractBalancedJsonObjectAt(text, i);
+    if (!extracted) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(extracted.objectText);
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        return true;
+      }
+    } catch {
+      // Ignore ordinary prose braces and object-shaped snippets that are not strict JSON.
+    }
+  }
+
+  return false;
+}
+
+function extractBalancedJsonObjectFromBlock(block: string): ExtractedJsonObject | null {
+  const leadingWhitespaceLength = block.length - block.trimStart().length;
+  const start = leadingWhitespaceLength;
+  const extracted = extractBalancedJsonObjectAt(block, start);
+  if (!extracted) {
+    return null;
+  }
+
+  const trailing = block.slice(extracted.endIndex);
+  return {
+    objectText: extracted.objectText,
+    ignoredTrailingContent: trailing.trim().length > 0,
+    ambiguousTrailingJsonObject: containsLaterStrictJsonObject(trailing)
+  };
 }
 
 export function extractTrailingJsonObject(text: string): string | null {
@@ -396,8 +435,8 @@ export function parseCompletionReport(lastMessage: string): ParsedCompletionRepo
   if (fencedMatch?.[1] !== undefined) {
     // Fenced reports are the preferred contract. Deterministically accept the
     // first balanced object in the fence only when it starts the JSON block;
-    // trailing prose is tolerated, but a second object is ambiguous and invalid.
-    // JSON.parse below remains the authority for whether the extracted object is strict JSON.
+    // trailing prose is tolerated, but any later strict JSON object is ambiguous
+    // and invalid. JSON.parse below remains the authority for the extracted object.
     const extracted = extractBalancedJsonObjectFromBlock(fencedMatch[1]);
     if (extracted?.ambiguousTrailingJsonObject) {
       return {

--- a/test/completionReportParser.test.ts
+++ b/test/completionReportParser.test.ts
@@ -65,6 +65,54 @@ test('parseCompletionReport accepts a trailing JSON object without a fence', () 
   assert.equal(parsed.report?.progressNote, 'Updated parser tests.');
 });
 
+test('parseCompletionReport accepts fenced JSON with trailing comment after object', () => {
+  const parsed = parseCompletionReport([
+    '```json',
+    '{',
+    '  "selectedTaskId": "T1",',
+    '  "requestedStatus": "done"',
+    '}',
+    '// completed successfully',
+    '```'
+  ].join('\n'));
+
+  assert.equal(parsed.status, 'parsed');
+  assert.equal(parsed.report?.selectedTaskId, 'T1');
+  assert.equal(parsed.report?.requestedStatus, 'done');
+  assert.match(parsed.warnings.join('\n'), /Ignored trailing content/);
+});
+
+test('parseCompletionReport accepts fenced JSON with trailing prose after object', () => {
+  const parsed = parseCompletionReport([
+    '```json',
+    '{',
+    '  "selectedTaskId": "T2",',
+    '  "requestedStatus": "in_progress"',
+    '}',
+    'Completed successfully after validation.',
+    '```'
+  ].join('\n'));
+
+  assert.equal(parsed.status, 'parsed');
+  assert.equal(parsed.report?.selectedTaskId, 'T2');
+  assert.equal(parsed.report?.requestedStatus, 'in_progress');
+  assert.match(parsed.warnings.join('\n'), /Ignored trailing content/);
+});
+
+test('parseCompletionReport rejects comments inside the JSON object', () => {
+  const parsed = parseCompletionReport([
+    '```json',
+    '{',
+    '  "selectedTaskId": "T1",',
+    '  // invalid JSONC comment',
+    '  "requestedStatus": "done"',
+    '}',
+    '```'
+  ].join('\n'));
+
+  assert.equal(parsed.status, 'invalid');
+});
+
 test('parseCompletionReport accepts suggested child tasks when provided', () => {
   const parsed = parseCompletionReport([
     '```json',

--- a/test/completionReportParser.test.ts
+++ b/test/completionReportParser.test.ts
@@ -113,6 +113,24 @@ test('parseCompletionReport rejects comments inside the JSON object', () => {
   assert.equal(parsed.status, 'invalid');
 });
 
+test('parseCompletionReport rejects fenced JSON with multiple report objects', () => {
+  const parsed = parseCompletionReport([
+    '```json',
+    '{',
+    '  "selectedTaskId": "T1",',
+    '  "requestedStatus": "done"',
+    '}',
+    '{',
+    '  "selectedTaskId": "T2",',
+    '  "requestedStatus": "blocked"',
+    '}',
+    '```'
+  ].join('\n'));
+
+  assert.equal(parsed.status, 'invalid');
+  assert.match(parsed.parseError ?? '', /multiple JSON objects/);
+});
+
 test('parseCompletionReport accepts suggested child tasks when provided', () => {
   const parsed = parseCompletionReport([
     '```json',

--- a/test/completionReportParserAmbiguity.test.ts
+++ b/test/completionReportParserAmbiguity.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseCompletionReport } from '../src/ralph/completionReportParser';
+
+test('parseCompletionReport rejects a second fenced report object after a trailing comment', () => {
+  const parsed = parseCompletionReport([
+    '```json',
+    '{',
+    '  "selectedTaskId": "T1",',
+    '  "requestedStatus": "done"',
+    '}',
+    '// revised report follows',
+    '{',
+    '  "selectedTaskId": "T2",',
+    '  "requestedStatus": "blocked"',
+    '}',
+    '```'
+  ].join('\n'));
+
+  assert.equal(parsed.status, 'invalid');
+  assert.match(parsed.parseError ?? '', /multiple JSON objects/);
+});
+
+test('parseCompletionReport rejects a second fenced report object after trailing prose', () => {
+  const parsed = parseCompletionReport([
+    '```json',
+    '{',
+    '  "selectedTaskId": "T1",',
+    '  "requestedStatus": "done"',
+    '}',
+    'Actually, use this corrected report instead:',
+    '{',
+    '  "selectedTaskId": "T2",',
+    '  "requestedStatus": "blocked"',
+    '}',
+    '```'
+  ].join('\n'));
+
+  assert.equal(parsed.status, 'invalid');
+  assert.match(parsed.parseError ?? '', /multiple JSON objects/);
+});
+
+test('parseCompletionReport accepts harmless trailing prose braces that are not strict JSON', () => {
+  const parsed = parseCompletionReport([
+    '```json',
+    '{',
+    '  "selectedTaskId": "T3",',
+    '  "requestedStatus": "done"',
+    '}',
+    'Note: this mentions braces like {not JSON} and should remain harmless.',
+    '```'
+  ].join('\n'));
+
+  assert.equal(parsed.status, 'parsed');
+  assert.equal(parsed.report?.selectedTaskId, 'T3');
+  assert.equal(parsed.report?.requestedStatus, 'done');
+  assert.match(parsed.warnings.join('\n'), /Ignored trailing content/);
+});


### PR DESCRIPTION
### Motivation

- Agents sometimes append prose or comments after a valid fenced JSON completion report object which caused the parser to mark the report as missing/invalid even though the JSON object itself was valid.
- The intent is to tolerate trailing text after a balanced JSON object only when the object itself is strict JSON, without accepting JSONC or repairing malformed JSON.

### Description

- Add a small balanced-object extractor `extractBalancedJsonObjectFromBlock` that walks a fenced block, respecting nested braces, quoted strings, escaped quotes, and escaped backslashes, and reports whether non-whitespace trailing content was ignored. (`src/ralph/completionReportParser.ts`)
- Prefer fenced `json` blocks and deterministically extract the first balanced JSON object that starts the fenced block; if trailing non-whitespace content follows the object, ignore it and push a parser warning: `Ignored trailing content after completion report JSON object.` (`src/ralph/completionReportParser.ts`)
- Preserve strict `JSON.parse` validation for the extracted object and continue to use the existing `extractTrailingJsonObject` behavior for non-fenced trailing JSON objects. (`src/ralph/completionReportParser.ts`)
- Add regression tests for: fenced JSON followed by trailing `//` comment, fenced JSON followed by trailing prose, and JSONC-style comments inside the object remaining invalid. (`test/completionReportParser.test.ts`)
- Document the rule in provenance docs clarifying that extraction remains strict JSON (not JSONC) and only trailing content after a balanced fenced object is tolerated with a warning. (`docs/provenance.md`)
- Deliberate non-changes: no provider-specific parser repair logic, no acceptance of JSONC, no changes to provider adapters, loop classification, task-state models, schema types, or UI.

### Testing

- Ran `npm run compile` and it completed successfully.
- Ran the targeted parser tests via `npm run compile:tests && node --require ./test/register-vscode-stub.cjs --test ./out-test/test/completionReportParser.test.js` and the new/updated `completionReportParser` tests all passed.
- Ran the full validation `npm run validate` (which includes compile, docs/ledger/prompt-budget checks, lint, and the test gate) and it completed successfully.

Files changed: `src/ralph/completionReportParser.ts`, `test/completionReportParser.test.ts`, `docs/provenance.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe66882be883268b21c44bf3d1da16)