### PR TITLE
ci: fix build-artifact guard false positive (exclude esbuild bundle)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,15 @@ jobs:
       - name: Verify committed build artifacts are current
         run: |
           # `npm run validate` already compiled src -> out. If the committed
-          # out/ drifted from source, the working tree is now dirty. Fail so
-          # stale build artifacts can never be merged.
-          if ! git diff --exit-code -- out/; then
+          # tsc output drifted from source, the working tree is now dirty. Fail
+          # so stale build artifacts can never be merged.
+          #
+          # out/webview-ui/ is excluded: it is produced by esbuild --minify
+          # --sourcemap and its sourcemap is not byte-reproducible across the
+          # dev (Windows) and CI (Linux) toolchains, so checking it here only
+          # yields false positives. That bundle is rebuilt by vscode:prepublish
+          # at packaging time regardless of its committed bytes.
+          if ! git diff --exit-code -- out/ ':(exclude)out/webview-ui/'; then
             echo "::error::Committed out/ is stale. Run 'npm run compile' and commit the result."
             exit 1
           fi


### PR DESCRIPTION
**Hotfix for `main`.** The build-artifact drift guard added in #76 is failing CI on every run, including `main` post-merge.

## Cause
The guard runs `git diff --exit-code -- out/` after `npm run validate` (which compiles). The committed `out/webview-ui/main.js.map` is produced by `esbuild --minify --sourcemap` and is **not byte-reproducible** across the dev (Windows) and CI (Linux) toolchains — only the sourcemap differs. So the guard is a permanent false positive. (The tsc output and even the esbuild `main.js` match; only the `.map` drifts.)

## Fix
Exclude `out/webview-ui/` from the guard via `':(exclude)out/webview-ui/'`. The guard still protects the deterministic tsc output (the extension code, the part that actually drifts harmfully); the esbuild bundle is rebuilt by `vscode:prepublish` at packaging time regardless of its committed bytes.

Verified the pathspec syntax locally. CI-config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)