### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Ralphdex are documented here.
 
+## [1.2.0] — 2026-05-29
+
+A quality-first release: stronger fundamentals, a clearer first-run and operator flow, and a large internal cleanup. No breaking changes to commands, settings, or workspace state.
+
+### Added
+
+- **Getting Started walkthrough** — a VS Code "Get started with Ralphdex" walkthrough guides new operators through creating a PRD, confirming their provider, running a first iteration, and reading the dashboard.
+- **Humanized stop reasons** — the status report and dashboard now show a plain-language label, explanation, and "what to do next" for every loop stop reason instead of raw enum values.
+
+### Changed
+
+- **Calmer command palette** — 16 niche/diagnostic commands (the "Open Latest …" artifact openers, doctrine sub-views and proposal commands, and redundant dashboard aliases) are hidden from the command palette. They remain fully available from the dashboard and programmatically; recovery commands stay visible.
+- **Trustworthy docs and PRD** — `.ralph/prd.md` now leads with a live "Current scope" section over an archived history; stale operator-mode-preset references were removed from operator-facing docs; AGENTS.md command labels are corrected and now locked against drift by `check:docs`.
+
+### Removed
+
+- **Duplicate dashboard renderer** — removed the legacy string-template dashboard/sidebar fallback (`panelHtml.ts`/`sidebarHtml.ts`) and the unused `UXrefresh/` prototype (~10,500 lines). The React UI under `src/webview-ui/` is the single renderer; if its bundle is ever missing, a small static "UI failed to load" page is shown.
+
+### Internal
+
+- Build hygiene: added `.gitattributes` (LF normalization) and a CI guard that fails if committed `out/` build output drifts from source.
+- Refactors (behaviour-preserving, snapshot/test-guarded): extracted the source-location JSON locator from `taskFile.ts`, the role-aware context-section builders from `promptBuilder.ts`, and the pre-execution planning gate from `iterationEngine.ts` (restoring it to a thin orchestrator). Added direct unit tests for the reconciliation gate pipeline and the new modules.
+
 ## [1.1.9] — 2026-05-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ralphdex",
   "displayName": "Ralphdex",
   "description": "VS Code extension for file-backed Ralphdex prompts, IDE handoff, and CLI exec loops.",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "publisher": "s0l0m0n8und9",
   "icon": "media/ralph-icon.png",
   "homepage": "https://github.com/S0l0m0n8und9/RalphDex#readme",


### PR DESCRIPTION
Release prep for **v1.2.0** — the quality-first program (PRs #76–#80, all merged to main).

## What's in this PR
- Bump `package.json` `1.1.9` → `1.2.0` (minor; new features + internal cleanup, no breaking changes).
- New `## [1.2.0]` CHANGELOG entry summarizing operator-visible changes.

## Verified
- `npm run validate` green (1423 tests, 0 fail).
- `npm run package` builds `ralphdex-1.2.0.vsix` with 0 blocking warnings (the "consider bundling" notice is the standard advisory; runtime deps are intentionally bundled).
- `main` CI green; working tree clean.

## After merge (release steps — require the Marketplace PAT)
```bash
git checkout main && git pull
git tag v1.2.0
git push origin main --tags
npm run package           # optional re-confirm
npx vsce publish          # needs VSCE_PAT for publisher s0l0m0n8und9
```
Then verify the listing at https://marketplace.visualstudio.com/items?itemName=s0l0m0n8und9.ralphdex

🤖 Generated with [Claude Code](https://claude.com/claude-code)