### PR TITLE
Record marketplace publish dry-run

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,8 +21,12 @@ tsconfig.tsbuildinfo
 .worktrees/**
 
 # Context and editor tooling files
+.github/**
 .claude/**
 .vscode/**
+AGENTS.md
+AGENTS.local.md
+.ralph-config.json
 
 # Project metadata not for distribution
 ralph.code-workspace

--- a/README.md
+++ b/README.md
@@ -202,12 +202,17 @@ Source of truth: `package.json` (`contributes.commands`) is authoritative for sh
 Current command surface:
 
 - `Ralphdex: Initialize Doctrine Pack`
+- `Ralphdex: Open Doctrine Folder`
+- `Ralphdex: Open Doctrine Invariants`
+- `Ralphdex: Open Doctrine Boundaries`
+- `Ralphdex: Open Doctrine Agents`
 - `Ralphdex: Add Task`
 - `Ralphdex: Seed Tasks from Feature Request`
 - `Ralphdex: Prepare IDE Prompt`
 - `Ralphdex: Open Codex IDE`
 - `Ralphdex: Run Single Iteration`
 - `Ralphdex: Run Loop`
+- `Ralphdex: Stop Loop`
 - `Ralphdex: Run Multi-Agent Loop`
 - `Ralphdex: Run Review Agent`
 - `Ralphdex: Run Watchdog Agent`
@@ -377,6 +382,7 @@ Permissive provider modes (`dangerously-skip-permissions`, `allow-all`) are avai
 - [docs/multi-agent-readiness.md](docs/multi-agent-readiness.md): historical record of the 2026-03-17 multi-agent readiness milestone
 - [docs/prompt-calibration.md](docs/prompt-calibration.md): token target derivation, recalibration procedure, and reasoning effort overhead
 - [docs/release-workflow.md](docs/release-workflow.md): version bump, packaging, and VS Code Marketplace publish procedure
+- [docs/marketplace-dry-run-2026-06-02.md](docs/marketplace-dry-run-2026-06-02.md): current VSIX packaging and packaged activation dry-run record
 - [docs/dogfooding-runbook.md](docs/dogfooding-runbook.md): manual live-provider runbook, evidence contract, redaction rules, and pass/fail criteria
 - [docs/failure-recovery.md](docs/failure-recovery.md): failure category taxonomy, recovery playbooks, and diagnostic cost
 - [docs/ui-state-fixtures.md](docs/ui-state-fixtures.md): deterministic dashboard/sidebar fixture catalogue for UI review and regression checks

--- a/docs/marketplace-dry-run-2026-06-02.md
+++ b/docs/marketplace-dry-run-2026-06-02.md
@@ -1,0 +1,57 @@
+# Marketplace Publish Dry-Run — 2026-06-02
+
+Issue: <https://github.com/S0l0m0n8und9/RalphDex/issues/100>
+
+Run timestamp: 2026-06-02 13:09 UTC / 2026-06-03 01:09 NZST
+
+## Result
+
+Status: pass with one non-blocking `vsce` warning.
+
+No publish blockers were found. The generated VSIX was not committed.
+
+## Commands Run
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| `npm run validate` | Pass | 1525 tests passed; compile, docs, ledger, prompt-budget, lint, and unit/webview tests completed. |
+| `npm run package` | Pass | Emitted `ralphdex-1.2.0.vsix`; final payload was 8519 files, 10.56 MB. |
+| `npm run publish:dry-run` | Pass | Aliased `npm run package` and completed without publishing. |
+| Focused packaging policy test | Pass | `releasePackaging.test.ts` verifies runtime dependencies are included and dev-only package junk is excluded. |
+| Packaged VSIX install and activation smoke | Pass | Installed `ralphdex-1.2.0.vsix` into a temporary VS Code extensions directory, activated `s0l0m0n8und9.ralphdex`, confirmed key commands registered, opened the dashboard, and received packaged React webview readiness for `dashboard`. |
+
+## Package Payload
+
+Confirmed included Marketplace/runtime surfaces:
+
+- `extension/readme.md`
+- `extension/changelog.md`
+- `extension/package.json`
+- `extension/media/ralph-icon.png`
+- `extension/out/webview-ui/main.js`
+- `extension/out/webview-ui/main.css`
+
+Removed package drift during this pass:
+
+- `.github/**`
+- `AGENTS.md`
+- `AGENTS.local.md`
+- `.ralph-config.json`
+
+These entries are development, CI, or agent-routing surfaces and are now excluded by `.vscodeignore`.
+
+## Marketplace Metadata Sanity
+
+- `package.json` version: `1.2.0`
+- `CHANGELOG.md` has `## [1.2.0]`
+- README Marketplace badge targets `s0l0m0n8und9.ralphdex`
+- Repository URL: `https://github.com/S0l0m0n8und9/RalphDex.git`
+- Icon path: `media/ralph-icon.png`
+- Contributed command count: 44
+- README command surface was refreshed to include all contributed command titles.
+
+## Remaining Warning
+
+`vsce` warns that the extension contains 8519 files, including 1221 JavaScript files, and recommends bundling/excluding more files for performance.
+
+Assessment: non-blocking for this dry-run. The large file count is dominated by runtime dependencies under `node_modules/`, which are intentionally included by the current package policy and guarded by `test/releasePackaging.test.ts`. A future package-size optimization can revisit extension bundling without blocking this release-readiness check.

--- a/test/releasePackaging.test.ts
+++ b/test/releasePackaging.test.ts
@@ -45,4 +45,19 @@ test('release packaging includes runtime dependencies and excludes local packagi
     /^\*\.vsix$/m,
     '.vscodeignore must exclude previously built VSIX files from the VSIX'
   );
+  assert.match(
+    vscodeIgnore,
+    /^\.github\/\*\*$/m,
+    '.vscodeignore must exclude GitHub workflow metadata from the VSIX'
+  );
+  assert.match(
+    vscodeIgnore,
+    /^AGENTS\.md$/m,
+    '.vscodeignore must exclude agent routing instructions from the VSIX'
+  );
+  assert.match(
+    vscodeIgnore,
+    /^\.ralph-config\.json$/m,
+    '.vscodeignore must exclude developer-loop shim config from the VSIX'
+  );
 });


### PR DESCRIPTION
Closes #100

## Summary
- records the current Marketplace publish dry-run evidence in `docs/marketplace-dry-run-2026-06-02.md`
- excludes dev-only root files (`.github/**`, `AGENTS*.md`, `.ralph-config.json`) from the VSIX payload
- refreshes README command-surface coverage and extends the packaging policy test

## Validation
- `npm run validate`
- `npm run publish:dry-run`
- packaged VSIX install + activation smoke in a temporary VS Code extensions directory, including dashboard React webview readiness

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR records the 2026-06-02 Marketplace publish dry-run evidence, removes dev-only files from the VSIX payload via `.vscodeignore`, and refreshes the README command-surface list to match the current `package.json`.

- **`.vscodeignore`** — Adds `.github/**`, `AGENTS.md`, `AGENTS.local.md`, and `.ralph-config.json` so CI metadata and agent-routing files are stripped from the packaged VSIX.
- **`test/releasePackaging.test.ts`** — Extends the packaging policy test with three new `assert.match` assertions covering the new exclusions (a fourth entry, `AGENTS.local.md`, is excluded in practice but not yet asserted).
- **`docs/marketplace-dry-run-2026-06-02.md` + `README.md`** — Adds the dry-run evidence record and registers it in the README doc index alongside five previously-missing command entries.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to the ignore list, test policy assertions, documentation, and README updates; no runtime or extension logic is touched.

All four changed files are non-runtime: `.vscodeignore` controls VSIX packaging only, the test additions guard the new exclusions, and the two doc/README edits are purely informational. The only gap is a missing test assertion for `AGENTS.local.md`, which is present in `.vscodeignore` but not yet guarded by the policy test — this does not affect extension behavior.

No files require special attention beyond the minor test coverage gap in `test/releasePackaging.test.ts` for `AGENTS.local.md`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .vscodeignore | Adds `.github/**`, `AGENTS.md`, `AGENTS.local.md`, and `.ralph-config.json` to exclude dev-only files from the VSIX payload; no issues found. |
| test/releasePackaging.test.ts | Extends packaging policy assertions for the three new exclusions; coverage for `AGENTS.local.md` (also added to `.vscodeignore`) is missing. |
| README.md | Adds five missing command entries to the command-surface list and registers the new dry-run evidence doc; documentation-only, no code issues. |
| docs/marketplace-dry-run-2026-06-02.md | New evidence record documenting the VSIX packaging dry-run results, payload contents, and one non-blocking `vsce` file-count warning; no code changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm run package / publish:dry-run] --> B[vsce reads .vscodeignore]
    B --> C{File in ignore list?}
    C -- Yes --> D[Excluded from VSIX]
    C -- No --> E[Included in VSIX]
    D --> F[".github/**\nAGENTS.md\nAGENTS.local.md\n.ralph-config.json\nsrc/** / test/**\n.ralph/** etc."]
    E --> G["extension/out/**\nextension/package.json\nextension/media/**\nnode_modules/**\n..."]
    G --> H["ralphdex-1.2.0.vsix\n8519 files / 10.56 MB"]
    H --> I[releasePackaging.test.ts\nverifies policy]
    I --> J{All assertions pass?}
    J -- Yes --> K[Dry-run PASS]
    J -- No --> L[Test failure — block release]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2FreleasePackaging.test.ts%3A53-57%0AThe%20PR%20adds%20%60AGENTS.local.md%60%20to%20%60.vscodeignore%60%20alongside%20%60AGENTS.md%60%2C%20but%20the%20test%20only%20asserts%20the%20presence%20of%20%60AGENTS.md%60.%20If%20%60AGENTS.local.md%60%20were%20accidentally%20removed%20from%20%60.vscodeignore%60%2C%20the%20test%20would%20not%20catch%20the%20regression.%20Adding%20a%20matching%20assertion%20keeps%20the%20policy%20symmetric%20with%20the%20actual%20ignore%20file.%0A%0A%60%60%60suggestion%0A%20%20assert.match%28%0A%20%20%20%20vscodeIgnore%2C%0A%20%20%20%20%2F%5EAGENTS%5C.md%24%2Fm%2C%0A%20%20%20%20'.vscodeignore%20must%20exclude%20agent%20routing%20instructions%20from%20the%20VSIX'%0A%20%20%29%3B%0A%20%20assert.match%28%0A%20%20%20%20vscodeIgnore%2C%0A%20%20%20%20%2F%5EAGENTS%5C.local%5C.md%24%2Fm%2C%0A%20%20%20%20'.vscodeignore%20must%20exclude%20local%20agent%20routing%20overrides%20from%20the%20VSIX'%0A%20%20%29%3B%0A%60%60%60%0A%0A&repo=s0l0m0n8und9%2Fralphdex&pr=107&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22s0l0m0n8und9%2Fralphdex%22%20on%20the%20existing%20branch%20%22issue-100-marketplace-dry-run%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22issue-100-marketplace-dry-run%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2FreleasePackaging.test.ts%3A53-57%0AThe%20PR%20adds%20%60AGENTS.local.md%60%20to%20%60.vscodeignore%60%20alongside%20%60AGENTS.md%60%2C%20but%20the%20test%20only%20asserts%20the%20presence%20of%20%60AGENTS.md%60.%20If%20%60AGENTS.local.md%60%20were%20accidentally%20removed%20from%20%60.vscodeignore%60%2C%20the%20test%20would%20not%20catch%20the%20regression.%20Adding%20a%20matching%20assertion%20keeps%20the%20policy%20symmetric%20with%20the%20actual%20ignore%20file.%0A%0A%60%60%60suggestion%0A%20%20assert.match%28%0A%20%20%20%20vscodeIgnore%2C%0A%20%20%20%20%2F%5EAGENTS%5C.md%24%2Fm%2C%0A%20%20%20%20'.vscodeignore%20must%20exclude%20agent%20routing%20instructions%20from%20the%20VSIX'%0A%20%20%29%3B%0A%20%20assert.match%28%0A%20%20%20%20vscodeIgnore%2C%0A%20%20%20%20%2F%5EAGENTS%5C.local%5C.md%24%2Fm%2C%0A%20%20%20%20'.vscodeignore%20must%20exclude%20local%20agent%20routing%20overrides%20from%20the%20VSIX'%0A%20%20%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Record marketplace publish dry-run"](https://github.com/s0l0m0n8und9/ralphdex/commit/3d5f0728483282c81d5cb26c4d7387b7012fe5b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35134880)</sub>

<!-- /greptile_comment -->