### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to Ralphdex are documented here.
 
+## [1.3.0] — 2026-06-05
+
+An operator-visibility release: new dashboard surfaces backed by a durable runtime event journal, safer artifact lifecycle handling, and a batch of reliability fixes. No breaking changes to commands, settings, or workspace state.
+
+### Added
+
+- **Run Trust Timeline** — a dashboard panel shows the execution-intent preview before a run and a per-run timeline afterward (iteration, review, recovery, and branch-SCM events) with a file-level diff summary, sourced from a new typed, append-only runtime event journal.
+- **PRD/backlog reconciliation** — the dashboard surfaces proposals that reconcile `.ralph/prd.md` scope against the task backlog, scoped to the live PRD scope so archived history does not produce false orphans.
+- **Artifact registry** — a canonical artifact registry and relationship index ties iteration provenance, diagnostics, and run artifacts together.
+- **Safer runtime cleanup** — "Clean Up Old Run Artifacts" now offers a dry-run preview, writes an audit manifest of what would be removed, and repairs latest-pointer references.
+- **Codex model readiness diagnostics** — preflight and status surface whether the configured Codex model is reachable.
+- **Windows shell-compatibility warning** — bash-style validation commands are flagged on hosts whose shell cannot run them.
+
+### Changed
+
+- **Validation evidence required before done** — a task is only reconciled to `done` once validation-command evidence is recorded for the iteration.
+- **Model-tiering config conflicts surfaced** — a disagreement between `ralphCodex.enableModelTiering` and `ralphCodex.modelTiering.enabled` is now reported at config-read time instead of being silently resolved.
+- **Non-retryable provider errors escalate** — provider failures such as authentication errors are escalated immediately instead of being retried, and the provider-error kind is stamped onto the iteration summary.
+- **Seed-task replenishment contract** — a seed-only backlog routes into backlog replenishment rather than the planning gate, and seed tasks are marked as requiring replacement.
+- **Hardened CLI shim automation contract** — the shim emits JSON on stdout even when argument parsing fails, redacts stderr in `--json` mode, and honors the `--` end-of-options marker.
+
+### Internal
+
+- **Headless UI test harness** — `test/ui` now runs under a jsdom + `@testing-library/react` harness with a mocked `acquireVsCodeApi`, covering click handlers, effects, and the full webview↔host message round-trip without a browser or Extension Development Host.
+- Added a React-first UI ownership guard, extended extension-host webview smoke coverage, full-workflow contract tests, and many new unit tests across the event journal, artifact registry, reconciliation, shim, and preflight modules.
+
 ## [1.2.0] — 2026-05-29
 
 A quality-first release: stronger fundamentals, a clearer first-run and operator flow, and a large internal cleanup. No breaking changes to commands, settings, or workspace state.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ralphdex",
   "displayName": "Ralphdex",
   "description": "VS Code extension for file-backed Ralphdex prompts, IDE handoff, and CLI exec loops.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "s0l0m0n8und9",
   "icon": "media/ralph-icon.png",
   "homepage": "https://github.com/S0l0m0n8und9/RalphDex#readme",


### PR DESCRIPTION
Version bump + CHANGELOG for the **1.3.0** Marketplace release. Code is already on `main`; this PR only bumps `package.json` and adds the CHANGELOG entry.

## Release contents (since 1.2.0)

**Added**
- Run Trust Timeline (execution-intent preview + per-run event timeline + file-level diff) backed by a typed runtime event journal
- PRD/backlog reconciliation proposals in the dashboard
- Canonical artifact registry + relationship index
- Safer runtime cleanup: dry-run preview, audit manifest, pointer repair
- Codex model readiness diagnostics; Windows validation-command shell warnings

**Changed**
- Validation-command evidence required before `done` reconciliation
- Model-tiering enable-flag conflict surfaced at config-read time
- Non-retryable provider errors escalate instead of retrying
- Seed-task replenishment contract; hardened CLI shim automation contract

**Internal**
- Headless UI test harness (jsdom + Testing Library), React-first ownership guard, expanded smoke/contract/unit coverage

## Release-workflow status (`docs/release-workflow.md`)
- [x] Baseline validate — clean (one confirmed timing flake in `processRunner`, passes 3/3 in isolation + clean pre-edit run + green CI)
- [x] Version bump → 1.3.0 (minor; no breaking changes)
- [x] CHANGELOG entry added
- [x] `npm run package` → `ralphdex-1.3.0.vsix`, 8522 files / 10.6 MB, 0 blocking warnings (only the standard "bundle your extension" notice)
- [x] `publish:dry-run` (aliases `npm run package`)
- [ ] Merge this PR
- [ ] `npx vsce publish` — **requires `VSCE_PAT`** (not set in the build environment; operator action)
- [ ] Tag `v1.3.0` after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a pure metadata release bump: `package.json` advances from `1.2.0` to `1.3.0` and `CHANGELOG.md` gains the corresponding release entry. All feature code described in the CHANGELOG was already merged to `main` in earlier commits; no source logic is touched here.

- **`package.json`** — version field updated from `1.2.0` → `1.3.0`; all other fields unchanged.
- **`CHANGELOG.md`** — new `[1.3.0]` section added with Added/Changed/Internal subsections that match the PR description; format mirrors the existing `[1.2.0]` entry.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only a version string and a CHANGELOG entry change; no source logic is touched.

Both changed files are metadata-only. The version bump is correct (minor increment, no breaking changes per the description), and the CHANGELOG entry format matches the existing pattern. The CHANGELOG date (2026-06-05) is one day after the current date, which appears intentional given that publishing and tagging are post-merge operator steps.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Single-line version bump from 1.2.0 to 1.3.0; no other fields changed. |
| CHANGELOG.md | New [1.3.0] entry added above [1.2.0]; format and structure are consistent with the existing entry. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PR as This PR (v1.3.0 bump)
    participant Main as main branch
    participant VSIX as ralphdex-1.3.0.vsix
    participant Marketplace as VS Code Marketplace

    PR->>Main: Merge (package.json 1.3.0 + CHANGELOG entry)
    Main->>VSIX: npx vsce package (already run, 8522 files / 10.6 MB)
    Main->>Marketplace: npx vsce publish (requires VSCE_PAT — operator action)
    Main->>Main: git tag v1.3.0
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump version to 1.3.0"](https://github.com/s0l0m0n8und9/ralphdex/commit/238079a0739255573024fa0f2cd52451a5556cdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35728000)</sub>

<!-- /greptile_comment -->