### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Ralphdex are documented here.
 
+## [1.3.1] — 2026-06-05
+
+A bug-fix release for webview interaction issues reported against 1.3.0.
+
+### Fixed
+
+- **PRD wizard text fields** — editing any field (objective, tech stack, out-of-scope, conventions, the draft PRD, and task title/notes/acceptance/dependencies) no longer bounces the caret to the end on every keystroke. Edits apply optimistically so the controlled inputs stay in sync with what you type.
+- **Settings checkboxes that "wouldn't untick"** — settings whose effective value is force-derived from another setting are now shown disabled with an explanation, instead of silently reverting when you click them:
+  - **Auto Replenish Backlog** and **Auto Apply Remediation** are managed by Autonomy Mode — set it to `supervised` to edit them directly.
+  - **Enable Model Tiering** is overridden by the legacy `ralphCodex.enableModelTiering` alias when it conflicts with `modelTiering.enabled`; change or remove that alias to edit tiering from the panel.
+
 ## [1.3.0] — 2026-06-05
 
 An operator-visibility release: new dashboard surfaces backed by a durable runtime event journal, safer artifact lifecycle handling, and a batch of reliability fixes. No breaking changes to commands, settings, or workspace state.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ralphdex",
   "displayName": "Ralphdex",
   "description": "VS Code extension for file-backed Ralphdex prompts, IDE handoff, and CLI exec loops.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "publisher": "s0l0m0n8und9",
   "icon": "media/ralph-icon.png",
   "homepage": "https://github.com/S0l0m0n8und9/RalphDex#readme",


### PR DESCRIPTION
Patch release for the two webview bugs reported against 1.3.0 (fixes already merged via #131). This PR bumps the version and adds the CHANGELOG entry.

## Fixed
- **PRD wizard text fields** — caret no longer jumps to the end on each keystroke (optimistic edits).
- **Settings checkboxes that wouldn't untick** — force-derived settings (Auto Replenish Backlog + Auto Apply Remediation under autonomous mode; Enable Model Tiering under the `enableModelTiering` alias conflict) are now disabled with an explanation instead of silently reverting.

## Release-workflow status
- [x] `npm run validate` — clean (exit 0)
- [x] version → 1.3.1; CHANGELOG entry added
- [x] `npm run package` → `ralphdex-1.3.1.vsix`, 0 blocking warnings
- [ ] merge → tag `v1.3.1` → `vsce publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This is a patch release PR that bumps the version to 1.3.1 and adds the corresponding CHANGELOG entry for two webview bug fixes already merged via #131.

- **`package.json`**: Single-line version field change from `1.3.0` to `1.3.1`; no other manifest fields touched.
- **`CHANGELOG.md`**: New `[1.3.1]` section prepended with accurate descriptions of both fixes (PRD wizard caret regression and force-derived settings checkbox disabling), referencing the correct setting identifiers (`ralphCodex.enableModelTiering`, `modelTiering.enabled`, `autonomyMode`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a version field in the manifest and a CHANGELOG entry.

Both changed files are purely administrative: one is a single-field version bump, the other is documentation. No runtime code, configuration logic, or schema is touched. The CHANGELOG entry correctly names the two fixes and uses accurate setting identifiers that match the existing package.json contributions.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Single-line version bump from 1.3.0 to 1.3.1; no other fields modified. |
| CHANGELOG.md | New [1.3.1] entry prepended at the top; accurately describes both webview fixes and references correct setting identifiers from package.json. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Bug fixes merged via PR #131] --> B[Bump version: 1.3.0 → 1.3.1]
    B --> C[Add CHANGELOG entry for 1.3.1]
    C --> D{npm run validate\nclean?}
    D -- Yes --> E[npm run package\n→ ralphdex-1.3.1.vsix]
    E --> F[Merge PR #132]
    F --> G[Tag v1.3.1]
    G --> H[vsce publish]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump version to 1.3.1"](https://github.com/s0l0m0n8und9/ralphdex/commit/56fc963429b5aa753b12d2f2aab5c03616e508db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35756723)</sub>

<!-- /greptile_comment -->